### PR TITLE
Fix Tensor.mean() silently dropping gradients

### DIFF
--- a/data/src/06_autograd/06_autograd.py
+++ b/data/src/06_autograd/06_autograd.py
@@ -3894,6 +3894,26 @@ def enable_autograd(quiet=False):
 
         return result
 
+    def mean_op(self, axis=None, keepdims=False):
+        """
+        Mean operation with gradient tracking.
+
+        Built from sum() and division rather than its own backward
+        Function: both already track gradients correctly by this point,
+        so this reuses two already-verified backward passes instead of
+        adding a third from scratch.
+        """
+        if axis is None:
+            n = self.data.size
+        elif isinstance(axis, tuple):
+            n = 1
+            for a in axis:
+                n *= self.data.shape[a]
+        else:
+            n = self.data.shape[axis]
+
+        return self.sum(axis=axis, keepdims=keepdims) / n
+
     def backward(self, gradient=None, retain_graph=False):
         """
         Compute gradients via backpropagation.
@@ -4010,6 +4030,7 @@ def enable_autograd(quiet=False):
     Tensor.transpose = tracked_transpose
     Tensor.reshape = tracked_reshape
     Tensor.sum = sum_op
+    Tensor.mean = mean_op
     Tensor.backward = backward
     Tensor.zero_grad = zero_grad
 

--- a/data/trentorch/core/activations.py
+++ b/data/trentorch/core/activations.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'TOLERANCE', 'Sigmoid', 'ReLU', 'Tanh', 'GELU', 'Softmax']
 
-# %% ../../solutions/02_activations/activations.ipynb #bf1c0041
+# %% ../../solutions/02_activations/activations.ipynb #e08bdf98
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -32,7 +32,7 @@ TOLERANCE = 1e-10  # Small tolerance for floating-point comparisons in tests
 # Export only activation classes
 __all__ = ['Sigmoid', 'ReLU', 'Tanh', 'GELU', 'Softmax']
 
-# %% ../../solutions/02_activations/activations.ipynb #187bdf1c
+# %% ../../solutions/02_activations/activations.ipynb #05b71c74
 # Solution
 
 class Sigmoid:
@@ -86,7 +86,7 @@ class Sigmoid:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #330f1fa2
+# %% ../../solutions/02_activations/activations.ipynb #24d9353f
 # Solution
 
 class ReLU:
@@ -130,7 +130,7 @@ class ReLU:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #24296968
+# %% ../../solutions/02_activations/activations.ipynb #0e1b7a42
 # Solution
 
 class Tanh:
@@ -174,7 +174,7 @@ class Tanh:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #aa028394
+# %% ../../solutions/02_activations/activations.ipynb #ed4e48e6
 # Solution
 
 class GELU:
@@ -218,7 +218,7 @@ class GELU:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #c2812e76
+# %% ../../solutions/02_activations/activations.ipynb #77cec5fd
 # Solution
 
 class Softmax:

--- a/data/trentorch/core/attention.py
+++ b/data/trentorch/core/attention.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'MASK_VALUE', 'scaled_dot_product_attention', 'MultiHeadAttention']
 
-# %% ../../solutions/12_attention/attention.ipynb #041843a4
+# %% ../../solutions/12_attention/attention.ipynb #8f9164ab
 #| default_exp core.attention
 #| export
 
-# %% ../../solutions/12_attention/attention.ipynb #054ed421
+# %% ../../solutions/12_attention/attention.ipynb #25b0ceab
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ from .activations import Softmax
 # Constants for attention computation
 MASK_VALUE = -1e9  # Large negative value used for attention masking (becomes ~0 after softmax)
 
-# %% ../../solutions/12_attention/attention.ipynb #d3cdfb1b
+# %% ../../solutions/12_attention/attention.ipynb #6c4de1f7
 # Solution
 
 def _compute_attention_scores(Q: Tensor, K: Tensor) -> Tensor:
@@ -62,7 +62,7 @@ def _compute_attention_scores(Q: Tensor, K: Tensor) -> Tensor:
     return Q.matmul(K_t)
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #5c525b95
+# %% ../../solutions/12_attention/attention.ipynb #45e8e742
 # Solution
 
 def _scale_scores(scores: Tensor, d_model: int) -> Tensor:
@@ -86,7 +86,7 @@ def _scale_scores(scores: Tensor, d_model: int) -> Tensor:
     return scores * scale_factor
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #770c60b8
+# %% ../../solutions/12_attention/attention.ipynb #00b2461e
 # Solution
 
 def _apply_mask(scores: Tensor, mask: Tensor) -> Tensor:
@@ -111,7 +111,7 @@ def _apply_mask(scores: Tensor, mask: Tensor) -> Tensor:
     return scores + adder
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #604533f5
+# %% ../../solutions/12_attention/attention.ipynb #d6df72a3
 # Solution
 
 def scaled_dot_product_attention(Q: Tensor, K: Tensor, V: Tensor, mask: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
@@ -162,7 +162,7 @@ def scaled_dot_product_attention(Q: Tensor, K: Tensor, V: Tensor, mask: Optional
     return output, attention_weights
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #9679b850
+# %% ../../solutions/12_attention/attention.ipynb #ff825e58
 # Solution
 
 class MultiHeadAttention:

--- a/data/trentorch/core/autograd.py
+++ b/data/trentorch/core/autograd.py
@@ -20,7 +20,7 @@ __all__ = ['rng', 'EPSILON', 'Function', 'AddBackward', 'MulBackward', 'SubBackw
            'SigmoidBackward', 'TanhBackward', 'SoftmaxBackward', 'GELUBackward', 'MSEBackward', 'BCEBackward',
            'CrossEntropyBackward', 'is_grad_enabled', 'no_grad', 'enable_autograd']
 
-# %% ../../solutions/06_autograd/autograd.ipynb #bff4c3a0
+# %% ../../solutions/06_autograd/autograd.ipynb #510b242f
 import numpy as np
 rng = np.random.default_rng(7)
 from typing import Optional, List, Tuple
@@ -32,7 +32,7 @@ from .tensor import Tensor
 # Constants for numerical differentiation
 EPSILON = 1e-7  # Small perturbation for numerical gradient computation
 
-# %% ../../solutions/06_autograd/autograd.ipynb #61c533a2
+# %% ../../solutions/06_autograd/autograd.ipynb #6abe1ad5
 class Function:
     """
     Base class for differentiable operations.
@@ -76,7 +76,7 @@ class Function:
         """
         raise NotImplementedError("Each Function must implement apply() method")
 
-# %% ../../solutions/06_autograd/autograd.ipynb #83b94f0a
+# %% ../../solutions/06_autograd/autograd.ipynb #fd699e4f
 # Solution
 
 def _reduce_broadcast_grad(grad, original_shape):
@@ -117,7 +117,7 @@ def _reduce_broadcast_grad(grad, original_shape):
     return grad
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #d4ba8473
+# %% ../../solutions/06_autograd/autograd.ipynb #fa059962
 # Solution
 
 class AddBackward(Function):
@@ -200,7 +200,7 @@ class AddBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #2e48df1e
+# %% ../../solutions/06_autograd/autograd.ipynb #735d0ffd
 # Solution
 
 class MulBackward(Function):
@@ -280,7 +280,7 @@ class MulBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #a69c5d0d
+# %% ../../solutions/06_autograd/autograd.ipynb #e0e3c2ae
 # Solution
 
 class SubBackward(Function):
@@ -340,7 +340,7 @@ class SubBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #13d8180c
+# %% ../../solutions/06_autograd/autograd.ipynb #d27e9d65
 # Solution
 
 class DivBackward(Function):
@@ -409,7 +409,7 @@ class DivBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #408619a6
+# %% ../../solutions/06_autograd/autograd.ipynb #9df2cbde
 # Solution
 
 class MatmulBackward(Function):
@@ -500,7 +500,7 @@ class MatmulBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #9cf67153
+# %% ../../solutions/06_autograd/autograd.ipynb #cd0eeb47
 # Solution
 
 class TransposeBackward(Function):
@@ -588,7 +588,7 @@ class TransposeBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #e93133ba
+# %% ../../solutions/06_autograd/autograd.ipynb #a2d8edb7
 # Solution
 
 class PermuteBackward(Function):
@@ -659,7 +659,7 @@ class PermuteBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #b1d76300
+# %% ../../solutions/06_autograd/autograd.ipynb #b232addf
 # Solution
 
 class SliceBackward(Function):
@@ -751,7 +751,7 @@ class SliceBackward(Function):
         return (grad_input,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #cdd7f9d2
+# %% ../../solutions/06_autograd/autograd.ipynb #902158d8
 # Solution
 
 class ReshapeBackward(Function):
@@ -824,7 +824,7 @@ class ReshapeBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #d4edd178
+# %% ../../solutions/06_autograd/autograd.ipynb #6cc1d521
 # Solution
 
 class SumBackward(Function):
@@ -892,7 +892,7 @@ class SumBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #9390d50b
+# %% ../../solutions/06_autograd/autograd.ipynb #82ba7642
 # Solution
 
 class ReLUBackward(Function):
@@ -943,7 +943,7 @@ class ReLUBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #098289dd
+# %% ../../solutions/06_autograd/autograd.ipynb #007fb8e7
 # Solution
 
 class SigmoidBackward(Function):
@@ -1002,7 +1002,7 @@ class SigmoidBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #4fc88aaa
+# %% ../../solutions/06_autograd/autograd.ipynb #cef069f8
 # Solution
 
 class TanhBackward(Function):
@@ -1061,7 +1061,7 @@ class TanhBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #b83cef44
+# %% ../../solutions/06_autograd/autograd.ipynb #55e1807d
 # Solution
 
 class SoftmaxBackward(Function):
@@ -1137,7 +1137,7 @@ class SoftmaxBackward(Function):
         return (None,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #fd83130e
+# %% ../../solutions/06_autograd/autograd.ipynb #bc3fce5c
 # Solution
 
 class GELUBackward(Function):
@@ -1195,7 +1195,7 @@ class GELUBackward(Function):
         return (None,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #1ec3b542
+# %% ../../solutions/06_autograd/autograd.ipynb #b3452e78
 # Solution
 
 class MSEBackward(Function):
@@ -1250,7 +1250,7 @@ class MSEBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #01f62c2b
+# %% ../../solutions/06_autograd/autograd.ipynb #7bb9869c
 # Solution
 
 class BCEBackward(Function):
@@ -1309,7 +1309,7 @@ class BCEBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #60020204
+# %% ../../solutions/06_autograd/autograd.ipynb #bfb55676
 # Solution
 
 def _stable_softmax(logits_data):
@@ -1346,7 +1346,7 @@ def _stable_softmax(logits_data):
     return exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #8cce8b7c
+# %% ../../solutions/06_autograd/autograd.ipynb #2f923bfe
 # Solution
 
 def _one_hot_encode(targets, batch_size, num_classes):
@@ -1381,7 +1381,7 @@ def _one_hot_encode(targets, batch_size, num_classes):
     return one_hot
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #dcf97ddc
+# %% ../../solutions/06_autograd/autograd.ipynb #2d1a5c74
 # Solution
 
 class CrossEntropyBackward(Function):
@@ -1453,7 +1453,7 @@ class CrossEntropyBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #e9df1bf2
+# %% ../../solutions/06_autograd/autograd.ipynb #38b5f36e
 # ===== Global Gradient Tracking Flag =====
 # Why this exists: During inference or parameter updates, we don't need to build
 # computation graphs. Skipping graph construction saves memory and time.
@@ -1518,7 +1518,7 @@ class no_grad:
         _GRAD_TRACKING_ENABLED = self._prev_state
         return False  # Don't suppress exceptions
 
-# %% ../../solutions/06_autograd/autograd.ipynb #d0fc5b39
+# %% ../../solutions/06_autograd/autograd.ipynb #90369612
 def enable_autograd(quiet=False):
     """
     Enable gradient tracking for all Tensor operations.
@@ -1827,6 +1827,26 @@ def enable_autograd(quiet=False):
 
         return result
 
+    def mean_op(self, axis=None, keepdims=False):
+        """
+        Mean operation with gradient tracking.
+
+        Built from sum() and division rather than its own backward
+        Function: both already track gradients correctly by this point,
+        so this reuses two already-verified backward passes instead of
+        adding a third from scratch.
+        """
+        if axis is None:
+            n = self.data.size
+        elif isinstance(axis, tuple):
+            n = 1
+            for a in axis:
+                n *= self.data.shape[a]
+        else:
+            n = self.data.shape[axis]
+
+        return self.sum(axis=axis, keepdims=keepdims) / n
+
     def backward(self, gradient=None, retain_graph=False):
         """
         Compute gradients via backpropagation.
@@ -1943,6 +1963,7 @@ def enable_autograd(quiet=False):
     Tensor.transpose = tracked_transpose
     Tensor.reshape = tracked_reshape
     Tensor.sum = sum_op
+    Tensor.mean = mean_op
     Tensor.backward = backward
     Tensor.zero_grad = zero_grad
 

--- a/data/trentorch/core/dataloader.py
+++ b/data/trentorch/core/dataloader.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'Dataset', 'TensorDataset', 'DataLoader', 'RandomHorizontalFlip', 'RandomCrop', 'Compose']
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #716e8424
+# %% ../../solutions/05_dataloader/dataloader.ipynb #f8ff5de2
 #| default_exp core.dataloader
 #| export
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #a2cb4077
+# %% ../../solutions/05_dataloader/dataloader.ipynb #ed9e5e41
 # Essential imports for data loading
 import random
 import sys
@@ -35,7 +35,7 @@ rng = np.random.default_rng(7)
 # Import real Tensor class from trentorch package
 from .tensor import Tensor
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #c98dc897
+# %% ../../solutions/05_dataloader/dataloader.ipynb #084e2b5a
 # Solution
 
 class Dataset(ABC):
@@ -90,7 +90,7 @@ class Dataset(ABC):
         pass
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #88f256b0
+# %% ../../solutions/05_dataloader/dataloader.ipynb #4c526e7c
 # Solution
 
 class TensorDataset(Dataset):
@@ -206,7 +206,7 @@ class TensorDataset(Dataset):
         return tuple(Tensor(tensor.data[idx]) for tensor in self.tensors)
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #90293a16
+# %% ../../solutions/05_dataloader/dataloader.ipynb #da85fae7
 # Solution
 
 class DataLoader:
@@ -363,7 +363,7 @@ class DataLoader:
         return tuple(batched_tensors)
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #8e6068c8
+# %% ../../solutions/05_dataloader/dataloader.ipynb #ae80ce11
 # Solution
 
 class RandomHorizontalFlip:
@@ -461,7 +461,7 @@ class RandomHorizontalFlip:
         return x
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #883a59e1
+# %% ../../solutions/05_dataloader/dataloader.ipynb #864bc84f
 # Solution
 
 def _pad_image(data, padding):
@@ -512,7 +512,7 @@ def _pad_image(data, padding):
         )
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #0e0992fd
+# %% ../../solutions/05_dataloader/dataloader.ipynb #f1076cb0
 # Solution
 
 def _random_crop_region(padded_h, padded_w, target_h, target_w):
@@ -538,7 +538,7 @@ def _random_crop_region(padded_h, padded_w, target_h, target_w):
     return top, left
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #0e63e043
+# %% ../../solutions/05_dataloader/dataloader.ipynb #bddc4364
 # Solution
 
 class RandomCrop:

--- a/data/trentorch/core/embeddings.py
+++ b/data/trentorch/core/embeddings.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'EmbeddingBackward', 'Embedding', 'PositionalEncoding',
            'create_sinusoidal_embeddings', 'EmbeddingLayer', 'emblayer_forward']
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #4579d4ab
+# %% ../../solutions/11_embeddings/embeddings.ipynb #3236e845
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #ff497f6e
+# %% ../../solutions/11_embeddings/embeddings.ipynb #04373dc6
 # Solution
 
 class EmbeddingBackward(Function):
@@ -118,7 +118,7 @@ class EmbeddingBackward(Function):
         return (grad_weight,)
         ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #3395a180
+# %% ../../solutions/11_embeddings/embeddings.ipynb #58a69725
 # Solution
 
 class Embedding:
@@ -219,7 +219,7 @@ class Embedding:
     def __repr__(self):
         return f"Embedding(vocab_size={self.vocab_size}, embed_dim={self.embed_dim})"
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #8207e9d5
+# %% ../../solutions/11_embeddings/embeddings.ipynb #cb580b7a
 # Solution
 
 class PositionalEncoding:
@@ -341,7 +341,7 @@ class PositionalEncoding:
     def __repr__(self):
         return f"PositionalEncoding(max_seq_len={self.max_seq_len}, embed_dim={self.embed_dim})"
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #eecf0e68
+# %% ../../solutions/11_embeddings/embeddings.ipynb #3ab9a2ce
 # Solution
 
 def _compute_sinusoidal_table(max_len: int, embed_dim: int) -> np.ndarray:
@@ -401,7 +401,7 @@ def _compute_sinusoidal_table(max_len: int, embed_dim: int) -> np.ndarray:
     return pe
     ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #0b08fa19
+# %% ../../solutions/11_embeddings/embeddings.ipynb #45227b9e
 # Solution
 
 def create_sinusoidal_embeddings(max_seq_len: int, embed_dim: int) -> Tensor:
@@ -434,7 +434,7 @@ def create_sinusoidal_embeddings(max_seq_len: int, embed_dim: int) -> Tensor:
     return Tensor(pe)
     ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #6eda9041
+# %% ../../solutions/11_embeddings/embeddings.ipynb #32a3bf7c
 # Solution
 
 class EmbeddingLayer:
@@ -520,7 +520,7 @@ class EmbeddingLayer:
                 f"embed_dim={self.embed_dim}, "
                 f"pos_encoding='{self.pos_encoding_type}')")
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #adc6e295
+# %% ../../solutions/11_embeddings/embeddings.ipynb #e11792c1
 # Solution
 
 # Continue the EmbeddingLayer class with forward and utility methods

--- a/data/trentorch/core/layers.py
+++ b/data/trentorch/core/layers.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'INIT_SCALE_FACTOR', 'HE_SCALE_FACTOR', 'DROPOUT_MIN_PROB', 'DROPOUT_MAX_PROB', 'Layer', 'Linear', 'Dropout',
            'Sequential']
 
-# %% ../../solutions/03_layers/layers.ipynb #3fb185e2
+# %% ../../solutions/03_layers/layers.ipynb #42de637e
 import os
 import numpy as np
 # Module-level RNG is seeded so Linear weight init is deterministic by default.
@@ -42,7 +42,7 @@ HE_SCALE_FACTOR = 2.0  # He initialization uses sqrt(2/fan_in) for ReLU
 DROPOUT_MIN_PROB = 0.0  # Minimum dropout probability (no dropout)
 DROPOUT_MAX_PROB = 1.0  # Maximum dropout probability (drop everything)
 
-# %% ../../solutions/03_layers/layers.ipynb #2cd39f14
+# %% ../../solutions/03_layers/layers.ipynb #cc8760d2
 class Layer:
     """
     Base class for all neural network layers.
@@ -91,7 +91,7 @@ class Layer:
         """String representation of the layer."""
         return f"{self.__class__.__name__}()"
 
-# %% ../../solutions/03_layers/layers.ipynb #24652879
+# %% ../../solutions/03_layers/layers.ipynb #0cd903e5
 # Solution
 
 class Linear(Layer):
@@ -213,7 +213,7 @@ class Linear(Layer):
         bias_str = f", bias={self.bias is not None}"
         return f"Linear(in_features={self.in_features}, out_features={self.out_features}{bias_str})"
 
-# %% ../../solutions/03_layers/layers.ipynb #093f331c
+# %% ../../solutions/03_layers/layers.ipynb #0c16d987
 # Solution
 
 class Dropout(Layer):
@@ -382,7 +382,7 @@ class Dropout(Layer):
     def __repr__(self):
         return f"Dropout(p={self.p})"
 
-# %% ../../solutions/03_layers/layers.ipynb #27cab117
+# %% ../../solutions/03_layers/layers.ipynb #66f3a59c
 class Sequential:
     """
     Container that chains layers together sequentially.

--- a/data/trentorch/core/losses.py
+++ b/data/trentorch/core/losses.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'EPSILON', 'log_softmax', 'MSELoss', 'CrossEntropyLoss', 'BinaryCrossEntropyLoss']
 
-# %% ../../solutions/04_losses/losses.ipynb #60997dfe
+# %% ../../solutions/04_losses/losses.ipynb #2aaba77e
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -31,7 +31,7 @@ from .layers import Linear
 # Constants for numerical stability
 EPSILON = 1e-7  # Small value to prevent log(0) and numerical instability
 
-# %% ../../solutions/04_losses/losses.ipynb #af52beee
+# %% ../../solutions/04_losses/losses.ipynb #6e68138a
 # Solution
 
 def log_softmax(x: Tensor, dim: int = -1) -> Tensor:
@@ -70,7 +70,7 @@ def log_softmax(x: Tensor, dim: int = -1) -> Tensor:
     return Tensor(result)
     ### END SOLUTION
 
-# %% ../../solutions/04_losses/losses.ipynb #0c442475
+# %% ../../solutions/04_losses/losses.ipynb #52413146
 # Solution
 
 class MSELoss:
@@ -129,7 +129,7 @@ class MSELoss:
         """
         pass
 
-# %% ../../solutions/04_losses/losses.ipynb #1dba2dd8
+# %% ../../solutions/04_losses/losses.ipynb #3a405bf8
 # Solution
 
 class CrossEntropyLoss:
@@ -192,7 +192,7 @@ class CrossEntropyLoss:
         """
         pass
 
-# %% ../../solutions/04_losses/losses.ipynb #7186a897
+# %% ../../solutions/04_losses/losses.ipynb #c1866ad3
 # Solution
 
 class BinaryCrossEntropyLoss:

--- a/data/trentorch/core/optimizers.py
+++ b/data/trentorch/core/optimizers.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'DEFAULT_LEARNING_RATE_SGD', 'DEFAULT_LEARNING_RATE_ADAM', 'DEFAULT_MOMENTUM', 'DEFAULT_BETA1', 'DEFAULT_BETA2',
            'DEFAULT_EPS', 'DEFAULT_WEIGHT_DECAY_ADAMW', 'Optimizer', 'SGD', 'Adam', 'AdamW']
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #b6cc5405
+# %% ../../solutions/07_optimizers/optimizers.ipynb #110ce474
 import numpy as np
 rng = np.random.default_rng(7)
 from typing import List, Union, Optional, Dict, Any
@@ -40,7 +40,7 @@ DEFAULT_BETA2 = 0.999  # Second moment decay rate for Adam
 DEFAULT_EPS = 1e-8  # Small epsilon for numerical stability in Adam
 DEFAULT_WEIGHT_DECAY_ADAMW = 0.01  # Default weight decay for AdamW
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #28ea7e63
+# %% ../../solutions/07_optimizers/optimizers.ipynb #7e617b27
 # Solution
 
 class Optimizer:
@@ -123,7 +123,7 @@ class Optimizer:
             f"                  param.data -= self.lr * param.grad.data"
         )
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #2e96c8ba
+# %% ../../solutions/07_optimizers/optimizers.ipynb #977e58bc
 # Solution
 
 class _ExtractGradientMixin:
@@ -162,7 +162,7 @@ class _ExtractGradientMixin:
 # Attach _extract_gradient to Optimizer so all subclasses inherit it
 Optimizer._extract_gradient = _ExtractGradientMixin._extract_gradient
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #1761a731
+# %% ../../solutions/07_optimizers/optimizers.ipynb #dcb34e66
 # Solution
 
 class SGD(Optimizer):
@@ -328,7 +328,7 @@ class SGD(Optimizer):
         self.step_count += 1
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #518e5ba0
+# %% ../../solutions/07_optimizers/optimizers.ipynb #bf77454a
 # Solution
 
 class Adam(Optimizer):
@@ -373,7 +373,7 @@ class Adam(Optimizer):
         self.v_buffers = [None for _ in self.params]  # Second moment (variance)
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #4a9a2d76
+# %% ../../solutions/07_optimizers/optimizers.ipynb #fdaae07c
 # Solution
 
 class _AdamUpdateMomentsMixin:
@@ -430,7 +430,7 @@ class _AdamUpdateMomentsMixin:
 # Attach _update_moments to Adam
 Adam._update_moments = _AdamUpdateMomentsMixin._update_moments
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #4227bbad
+# %% ../../solutions/07_optimizers/optimizers.ipynb #f4aee6b6
 # Solution
 
 class _AdamStepMixin:
@@ -482,7 +482,7 @@ class _AdamStepMixin:
 # Attach step to Adam
 Adam.step = _AdamStepMixin.step
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #92774a6a
+# %% ../../solutions/07_optimizers/optimizers.ipynb #31d1ceb8
 # Solution
 
 class AdamW(Optimizer):
@@ -525,7 +525,7 @@ class AdamW(Optimizer):
         self.v_buffers = [None for _ in self.params]
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #eaecf5eb
+# %% ../../solutions/07_optimizers/optimizers.ipynb #275284a3
 # Solution
 
 class _AdamWUpdateMomentsMixin:
@@ -578,7 +578,7 @@ class _AdamWUpdateMomentsMixin:
 # Attach _update_moments to AdamW
 AdamW._update_moments = _AdamWUpdateMomentsMixin._update_moments
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #1d3c873a
+# %% ../../solutions/07_optimizers/optimizers.ipynb #178150c8
 # Solution
 
 class _AdamWStepMixin:

--- a/data/trentorch/core/spatial.py
+++ b/data/trentorch/core/spatial.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'DEFAULT_KERNEL_SIZE', 'DEFAULT_STRIDE', 'DEFAULT_PADDING', 'B
            'validate_4d_input', 'Conv2dBackward', 'Conv2d', 'MaxPool2dBackward', 'MaxPool2d', 'AvgPool2dBackward',
            'AvgPool2d', 'BatchNorm2d', 'SimpleCNN']
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #52387cbc
+# %% ../../solutions/09_convolutions/convolutions.ipynb #a364489e
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -41,7 +41,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #0bc8b7bd
+# %% ../../solutions/09_convolutions/convolutions.ipynb #e22ea2fa
 def validate_4d_input(x, layer_name):
     """
     Validate that input tensor is 4D (batch, channels, height, width).
@@ -81,7 +81,7 @@ def validate_4d_input(x, layer_name):
             f"  Reshape your input to 4D with the correct dimensions"
         )
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #2a800281
+# %% ../../solutions/09_convolutions/convolutions.ipynb #7597ea08
 # Solution
 
 class Conv2dBackward(Function):
@@ -436,7 +436,7 @@ class Conv2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #1d40bfb2
+# %% ../../solutions/09_convolutions/convolutions.ipynb #413408c9
 # Solution
 
 class MaxPool2dBackward(Function):
@@ -690,7 +690,7 @@ class MaxPool2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #2b0803e1
+# %% ../../solutions/09_convolutions/convolutions.ipynb #68cf3462
 # Solution
 
 class AvgPool2dBackward(Function):
@@ -933,7 +933,7 @@ class AvgPool2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #bde25836
+# %% ../../solutions/09_convolutions/convolutions.ipynb #8b87bbaa
 # Solution
 
 class BatchNorm2d:
@@ -1140,7 +1140,7 @@ class BatchNorm2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #848533d0
+# %% ../../solutions/09_convolutions/convolutions.ipynb #8c91a19e
 # Solution
 
 class SimpleCNN:

--- a/data/trentorch/core/tensor.py
+++ b/data/trentorch/core/tensor.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'Tensor']
 
-# %% ../../solutions/01_tensor/tensor.ipynb #409a58fc
+# %% ../../solutions/01_tensor/tensor.ipynb #45223d5e
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -27,7 +27,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/01_tensor/tensor.ipynb #bb92e2f0
+# %% ../../solutions/01_tensor/tensor.ipynb #f00ee192
 # Solution
 
 class Tensor:

--- a/data/trentorch/core/tokenization.py
+++ b/data/trentorch/core/tokenization.py
@@ -18,7 +18,7 @@
 __all__ = ['KB_TO_BYTES', 'Tokenizer', 'CharTokenizer', 'BPETokenizer', 'create_tokenizer', 'tokenize_dataset',
            'analyze_tokenization']
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #bddd7f0a
+# %% ../../solutions/10_tokenization/tokenization.ipynb #a89e3f00
 from collections import Counter
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -28,7 +28,7 @@ import numpy as np
 # Constants for memory calculations
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #4e7fe372
+# %% ../../solutions/10_tokenization/tokenization.ipynb #1efede9e
 # Solution
 
 class Tokenizer:
@@ -92,7 +92,7 @@ class Tokenizer:
         )
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #68ad8263
+# %% ../../solutions/10_tokenization/tokenization.ipynb #62fd4534
 # Solution
 
 class CharTokenizer(Tokenizer):
@@ -217,7 +217,7 @@ class CharTokenizer(Tokenizer):
         return ''.join(chars)
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #49e13448
+# %% ../../solutions/10_tokenization/tokenization.ipynb #973b5a18
 # Solution
 
 def _count_byte_pairs(word_tokens: Dict[str, List[str]], word_freq: Counter) -> Counter:
@@ -257,7 +257,7 @@ def _count_byte_pairs(word_tokens: Dict[str, List[str]], word_freq: Counter) -> 
     return pair_counts
     ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #bfd0e67a
+# %% ../../solutions/10_tokenization/tokenization.ipynb #abd09df0
 # Solution
 
 def _merge_pair(word_tokens: Dict[str, List[str]], pair: Tuple[str, str]) -> str:
@@ -311,7 +311,7 @@ def _merge_pair(word_tokens: Dict[str, List[str]], pair: Tuple[str, str]) -> str
     return merged_token
     ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #1411753c
+# %% ../../solutions/10_tokenization/tokenization.ipynb #ceb0d1c6
 # Solution
 
 class BPETokenizer(Tokenizer):
@@ -600,7 +600,7 @@ class BPETokenizer(Tokenizer):
         return text
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #18097f74
+# %% ../../solutions/10_tokenization/tokenization.ipynb #441db6c1
 # Solution
 
 def create_tokenizer(strategy: str = "char", vocab_size: int = 1000, corpus: List[str] = None) -> Tokenizer:

--- a/data/trentorch/core/training.py
+++ b/data/trentorch/core/training.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'DEFAULT_MAX_LR', 'DEFAULT_MIN_LR', 'DEFAULT_TOTAL_EPOCHS', 'C
            'trainer_init', 'trainer_train_epoch', 'trainer_evaluate', 'trainer_save_checkpoint',
            'trainer_load_checkpoint']
 
-# %% ../../solutions/08_training/training.ipynb #8558a7df
+# %% ../../solutions/08_training/training.ipynb #c7c2f6d0
 import numpy as np
 rng = np.random.default_rng(7)
 import pickle
@@ -44,7 +44,7 @@ DEFAULT_MAX_LR = 0.1  # Default maximum learning rate for cosine schedule
 DEFAULT_MIN_LR = 0.01  # Default minimum learning rate for cosine schedule
 DEFAULT_TOTAL_EPOCHS = 100  # Default total epochs for learning rate schedule
 
-# %% ../../solutions/08_training/training.ipynb #8df31893
+# %% ../../solutions/08_training/training.ipynb #629ede31
 # Solution
 
 class CosineSchedule:
@@ -85,7 +85,7 @@ class CosineSchedule:
         return self.min_lr + (self.max_lr - self.min_lr) * cosine_factor
     ### END SOLUTION
 
-# %% ../../solutions/08_training/training.ipynb #1bbafca2
+# %% ../../solutions/08_training/training.ipynb #408b8653
 # Solution
 
 def clip_grad_norm(parameters: List, max_norm: float = 1.0) -> float:
@@ -148,7 +148,7 @@ def clip_grad_norm(parameters: List, max_norm: float = 1.0) -> float:
     return float(total_norm)
     ### END SOLUTION
 
-# %% ../../solutions/08_training/training.ipynb #b3cc0824
+# %% ../../solutions/08_training/training.ipynb #7231d068
 class Trainer:
     """
     Complete training orchestrator for neural networks.
@@ -210,7 +210,7 @@ class Trainer:
             if hasattr(self.scheduler, key):
                 setattr(self.scheduler, key, value)
 
-# %% ../../solutions/08_training/training.ipynb #deb92457
+# %% ../../solutions/08_training/training.ipynb #e60ffa8b
 # Solution
 
 def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm=None):
@@ -272,7 +272,7 @@ def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm
 
 Trainer.__init__ = trainer_init
 
-# %% ../../solutions/08_training/training.ipynb #21b68057
+# %% ../../solutions/08_training/training.ipynb #16182b87
 # Solution
 
 def _trainer_process_batch(self, inputs, targets, accumulation_steps):
@@ -314,7 +314,7 @@ def _trainer_process_batch(self, inputs, targets, accumulation_steps):
 
 Trainer._process_batch = _trainer_process_batch
 
-# %% ../../solutions/08_training/training.ipynb #cf8b06c2
+# %% ../../solutions/08_training/training.ipynb #40eea921
 # Solution
 
 def _trainer_optimizer_update(self):
@@ -339,7 +339,7 @@ def _trainer_optimizer_update(self):
 
 Trainer._optimizer_update = _trainer_optimizer_update
 
-# %% ../../solutions/08_training/training.ipynb #c0284ef8
+# %% ../../solutions/08_training/training.ipynb #b9ffab9a
 # Solution
 
 def trainer_train_epoch(self, dataloader, accumulation_steps=1):
@@ -404,7 +404,7 @@ def trainer_train_epoch(self, dataloader, accumulation_steps=1):
 
 Trainer.train_epoch = trainer_train_epoch
 
-# %% ../../solutions/08_training/training.ipynb #01dc140e
+# %% ../../solutions/08_training/training.ipynb #2a6c7bb3
 # Solution
 
 def trainer_evaluate(self, dataloader):
@@ -474,7 +474,7 @@ def trainer_evaluate(self, dataloader):
 
 Trainer.evaluate = trainer_evaluate
 
-# %% ../../solutions/08_training/training.ipynb #6c145d96
+# %% ../../solutions/08_training/training.ipynb #6b327c88
 # Solution
 
 def trainer_save_checkpoint(self, path: str):
@@ -518,7 +518,7 @@ def trainer_save_checkpoint(self, path: str):
 
 Trainer.save_checkpoint = trainer_save_checkpoint
 
-# %% ../../solutions/08_training/training.ipynb #8f142951
+# %% ../../solutions/08_training/training.ipynb #05c3253c
 # Solution
 
 def trainer_load_checkpoint(self, path: str):

--- a/data/trentorch/core/transformers.py
+++ b/data/trentorch/core/transformers.py
@@ -18,11 +18,11 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'MB_TO_BYTES', 'TinyGPT', 'create_causal_mask', 'LayerNorm', 'MLP', 'TransformerBlock',
            'GPT']
 
-# %% ../../solutions/13_transformers/transformers.ipynb #e6992a40
+# %% ../../solutions/13_transformers/transformers.ipynb #16a3b520
 #| default_exp core.transformers
 #| export
 
-# %% ../../solutions/13_transformers/transformers.ipynb #86fc72e5
+# %% ../../solutions/13_transformers/transformers.ipynb #1bc9c612
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -72,7 +72,7 @@ def create_causal_mask(seq_len: int) -> Tensor:
     mask = np.tril(np.ones((seq_len, seq_len), dtype=np.float32))
     return Tensor(mask[np.newaxis, :, :])  # Add batch dimension
 
-# %% ../../solutions/13_transformers/transformers.ipynb #afe3b193
+# %% ../../solutions/13_transformers/transformers.ipynb #87f43326
 # Solution
 
 
@@ -217,7 +217,7 @@ class LayerNorm:
         """Return learnable parameters."""
         return [self.gamma, self.beta]
 
-# %% ../../solutions/13_transformers/transformers.ipynb #515caf52
+# %% ../../solutions/13_transformers/transformers.ipynb #8d29a28f
 # Solution
 
 class MLP:
@@ -300,7 +300,7 @@ class MLP:
         params.extend(self.linear2.parameters())
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #16bb0718
+# %% ../../solutions/13_transformers/transformers.ipynb #fbb4d8ee
 # Solution
 
 class TransformerBlock:
@@ -409,7 +409,7 @@ class TransformerBlock:
         params.extend(self.mlp.parameters())
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #9a6b4764
+# %% ../../solutions/13_transformers/transformers.ipynb #be89f349
 # Solution
 
 class GPT:
@@ -614,6 +614,6 @@ class GPT:
 
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #05c2c4e9
+# %% ../../solutions/13_transformers/transformers.ipynb #a8a9ed09
 # Alias for backward compatibility with tests
 TinyGPT = GPT

--- a/data/trentorch/olympics.py
+++ b/data/trentorch/olympics.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'SimpleMLP', 'BenchmarkReport', 'generate_submission', 'save_submission']
 
-# %% ../solutions/20_capstone/capstone.ipynb #991b0afa
+# %% ../solutions/20_capstone/capstone.ipynb #bb0b9be2
 #| default_exp olympics
 #| export
 
-# %% ../solutions/20_capstone/capstone.ipynb #97be347a
+# %% ../solutions/20_capstone/capstone.ipynb #aabf16a5
 import numpy as np
 rng = np.random.default_rng(7)
 import time
@@ -31,7 +31,7 @@ from typing import Dict, List, Tuple, Optional, Any
 import platform
 import sys
 
-# %% ../solutions/20_capstone/capstone.ipynb #9ef77172
+# %% ../solutions/20_capstone/capstone.ipynb #01eb846c
 # Solution
 
 class SimpleMLP:
@@ -118,7 +118,7 @@ class SimpleMLP:
 if __name__ == "__main__":
     print("✅ SimpleMLP model defined")
 
-# %% ../solutions/20_capstone/capstone.ipynb #a0d85f44
+# %% ../solutions/20_capstone/capstone.ipynb #bdd77565
 # Solution
 
 class BenchmarkReport:
@@ -262,7 +262,7 @@ class BenchmarkReport:
 if __name__ == "__main__":
     print("✅ BenchmarkReport class defined")
 
-# %% ../solutions/20_capstone/capstone.ipynb #7c2921ec
+# %% ../solutions/20_capstone/capstone.ipynb #239a69ff
 def generate_submission(
     baseline_report: BenchmarkReport,
     optimized_report: Optional[BenchmarkReport] = None,

--- a/data/trentorch/perf/acceleration.py
+++ b/data/trentorch/perf/acceleration.py
@@ -18,11 +18,11 @@
 __all__ = ['rng', 'DEFAULT_WARMUP_ITERATIONS', 'DEFAULT_TIMING_ITERATIONS', 'BYTES_PER_FLOAT32', 'vectorized_matmul',
            'fused_gelu', 'tiled_matmul']
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #0704cc66
+# %% ../../solutions/17_acceleration/acceleration.ipynb #6bfba28d
 #| default_exp perf.acceleration
 #| export
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #6874f83f
+# %% ../../solutions/17_acceleration/acceleration.ipynb #dbdaf9a0
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -35,11 +35,11 @@ DEFAULT_WARMUP_ITERATIONS = 2  # Default warmup iterations for timing
 DEFAULT_TIMING_ITERATIONS = 5  # Default timing iterations for measurement
 BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #fd147d52
+# %% ../../solutions/17_acceleration/acceleration.ipynb #717b2641
 # Import from TrenTorch package (previous modules must be completed and exported)
 from ..core.tensor import Tensor
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #78dc0929
+# %% ../../solutions/17_acceleration/acceleration.ipynb #9c3874c8
 # Solution
 
 def vectorized_matmul(a: Tensor, b: Tensor) -> Tensor:
@@ -112,7 +112,7 @@ def vectorized_matmul(a: Tensor, b: Tensor) -> Tensor:
     return Tensor(result_data)
     ### END SOLUTION
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #1a80f3c0
+# %% ../../solutions/17_acceleration/acceleration.ipynb #8a5cabff
 # Solution
 
 def fused_gelu(x: Tensor) -> Tensor:
@@ -175,7 +175,7 @@ def fused_gelu(x: Tensor) -> Tensor:
     return Tensor(result_data)
     ### END SOLUTION
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #8b4da566
+# %% ../../solutions/17_acceleration/acceleration.ipynb #78cfff1b
 # Solution
 
 def tiled_matmul(a: Tensor, b: Tensor, tile_size: int = 64) -> Tensor:

--- a/data/trentorch/perf/benchmarking.py
+++ b/data/trentorch/perf/benchmarking.py
@@ -21,12 +21,12 @@ __all__ = ['DEFAULT_WARMUP_RUNS', 'DEFAULT_MEASUREMENT_RUNS', 'rng', 'BenchmarkR
            'benchsuite_plot_pareto_frontier', 'benchsuite_generate_report', 'MLPerf', 'mlperf_run_standard_benchmark',
            'mlperf_run_all_benchmarks', 'mlperf_generate_compliance_report', 'analyze_optimization_techniques']
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #77abdb89
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9b711724
 # Constants for benchmarking defaults
 DEFAULT_WARMUP_RUNS = 5  # Default warmup runs for JIT compilation and cache warming
 DEFAULT_MEASUREMENT_RUNS = 10  # Default measurement runs for statistical significance
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #35dab04d
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d9739b0a
 import numpy as np
 rng = np.random.default_rng(7)
 import time
@@ -89,7 +89,7 @@ except ImportError:
 # Import Profiler from Module 14 for measurement reuse
 from .profiling import Profiler
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #129093ab
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #7b7b5442
 # Solution
 
 @dataclass
@@ -166,7 +166,7 @@ class BenchmarkResult:
         return f"{self.metric_name}: {self.mean:.4f} ± {self.std:.4f} (n={self.count})"
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #e36889b6
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #23ef19be
 # Solution
 
 @contextmanager
@@ -211,7 +211,7 @@ def precise_timer():
         timer.elapsed = time.perf_counter() - timer.start_time
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #c0c6f43a
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #c090fa04
 # Solution
 
 class Benchmark:
@@ -265,7 +265,7 @@ class Benchmark:
         # Process memory measurement uses tracemalloc (via Profiler)
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ad51cc4b
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #42e1a920
 # Solution
 
     # --- Benchmark.run_latency_benchmark ---
@@ -325,7 +325,7 @@ def benchmark_run_latency_benchmark(self, input_shape: Tuple[int, ...] = (1, 28,
 
 Benchmark.run_latency_benchmark = benchmark_run_latency_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #07e33479
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ce9975d3
 # Solution
 
     # --- Benchmark.run_accuracy_benchmark ---
@@ -381,7 +381,7 @@ def benchmark_run_accuracy_benchmark(self) -> Dict[str, BenchmarkResult]:
 
 Benchmark.run_accuracy_benchmark = benchmark_run_accuracy_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #dae6affb
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #3f1774b3
 # Solution
 
     # --- Benchmark.run_memory_benchmark ---
@@ -432,7 +432,7 @@ def benchmark_run_memory_benchmark(self, input_shape: Tuple[int, ...] = (1, 28, 
 
 Benchmark.run_memory_benchmark = benchmark_run_memory_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #4f355d18
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #fc26ca82
 # Solution
 
     # --- Benchmark.compare_models ---
@@ -485,7 +485,7 @@ def benchmark_compare_models(self, metric: str = "latency"):
 
 Benchmark.compare_models = benchmark_compare_models
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #64a7246b
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2eaba677
 # Solution
 
 class BenchmarkSuite:
@@ -528,7 +528,7 @@ class BenchmarkSuite:
         self.results = {}
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #3eae2ab9
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #a8b40866
 # Solution
 
     # --- BenchmarkSuite.run_full_benchmark ---
@@ -571,7 +571,7 @@ def benchsuite_run_full_benchmark(self) -> Dict[str, Dict[str, BenchmarkResult]]
 
 BenchmarkSuite.run_full_benchmark = benchsuite_run_full_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2acad982
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f775628e
 # Solution
 
     # --- BenchmarkSuite._estimate_energy_efficiency ---
@@ -633,7 +633,7 @@ def _benchsuite_estimate_energy_efficiency(self) -> Dict[str, BenchmarkResult]:
 
 BenchmarkSuite._estimate_energy_efficiency = _benchsuite_estimate_energy_efficiency
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #cfdf1068
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #60818475
 # Solution
 
     # --- BenchmarkSuite.plot_results and plot_pareto_frontier ---
@@ -775,7 +775,7 @@ def benchsuite_plot_pareto_frontier(self, x_metric: str = 'latency', y_metric: s
 
 BenchmarkSuite.plot_pareto_frontier = benchsuite_plot_pareto_frontier
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #1cc7bb8f
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #e099227b
 # Solution
 
 def _benchsuite_format_results_summary(self) -> List[str]:
@@ -823,7 +823,7 @@ def _benchsuite_format_results_summary(self) -> List[str]:
 
 BenchmarkSuite._format_results_summary = _benchsuite_format_results_summary
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d77f1504
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9ae30924
 # Solution
 
 def _benchsuite_format_recommendations(self) -> List[str]:
@@ -897,7 +897,7 @@ def _benchsuite_format_recommendations(self) -> List[str]:
 
 BenchmarkSuite._format_recommendations = _benchsuite_format_recommendations
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9afd44bd
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #040b82ef
 # Solution
 
 def benchsuite_generate_report(self) -> str:
@@ -950,7 +950,7 @@ def benchsuite_generate_report(self) -> str:
 
 BenchmarkSuite.generate_report = benchsuite_generate_report
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ecf12f7b
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2a4f4398
 # Solution
 
 class MLPerf:
@@ -1017,7 +1017,7 @@ class MLPerf:
         }
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #4c40f805
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #4e52e46d
 # Solution
 
     # --- MLPerf._run_latency_test ---
@@ -1081,7 +1081,7 @@ def _mlperf_run_latency_test(self, model: Any, test_inputs: List[Any],
 
 MLPerf._run_latency_test = _mlperf_run_latency_test
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #b50bd46c
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d98f0c2a
 # Solution
 
 def _extract_pred_array(pred) -> np.ndarray:
@@ -1117,7 +1117,7 @@ def _extract_pred_array(pred) -> np.ndarray:
     return pred_array
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #daf431a4
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #101e63ee
 # Solution
 
 def _mlperf_run_accuracy_test(self, model: Any, predictions: List[Any],
@@ -1174,7 +1174,7 @@ def _mlperf_run_accuracy_test(self, model: Any, predictions: List[Any],
 
 MLPerf._run_accuracy_test = _mlperf_run_accuracy_test
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #e2faca45
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #63803d26
 # Solution
 
     # --- MLPerf.run_standard_benchmark ---
@@ -1283,7 +1283,7 @@ def mlperf_run_all_benchmarks(self, model: Any) -> Dict[str, Dict[str, Any]]:
 
 MLPerf.run_all_benchmarks = mlperf_run_all_benchmarks
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #6197eba1
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ff0f2afe
 # Solution
 
 def _mlperf_compile_report_data(self, results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
@@ -1357,7 +1357,7 @@ def _mlperf_compile_report_data(self, results: Dict[str, Dict[str, Any]]) -> Dic
 
 MLPerf._compile_report_data = _mlperf_compile_report_data
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #36a32948
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #629a2261
 # Solution
 
 def _mlperf_format_compliance_summary(self, report_data: Dict[str, Any]) -> str:
@@ -1410,7 +1410,7 @@ def _mlperf_format_compliance_summary(self, report_data: Dict[str, Any]) -> str:
 
 MLPerf._format_compliance_summary = _mlperf_format_compliance_summary
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #e0dbaf16
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #1f460de0
 # Solution
 
 def mlperf_generate_compliance_report(self, results: Dict[str, Dict[str, Any]],
@@ -1449,7 +1449,7 @@ def mlperf_generate_compliance_report(self, results: Dict[str, Dict[str, Any]],
 
 MLPerf.generate_compliance_report = mlperf_generate_compliance_report
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2c3ca515
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #0bae017a
 # Solution
 
 def _collect_base_metrics(base_name: str, benchmark_results: Dict) -> Dict[str, float]:
@@ -1476,7 +1476,7 @@ def _collect_base_metrics(base_name: str, benchmark_results: Dict) -> Dict[str, 
     return base_metrics
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #8de419bd
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #7f8e22e3
 # Solution
 
 def _calculate_improvements(base_metrics: Dict[str, float], opt_metrics: Dict[str, float]) -> Dict[str, float]:
@@ -1514,7 +1514,7 @@ def _calculate_improvements(base_metrics: Dict[str, float], opt_metrics: Dict[st
     return improvements
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f04f8631
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9ac43e11
 # Solution
 
 def _generate_recommendations(all_improvements: Dict[str, Dict[str, float]]) -> Dict[str, Dict]:
@@ -1601,7 +1601,7 @@ def _generate_recommendations(all_improvements: Dict[str, Dict[str, float]]) -> 
     }
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #140b0d14
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f690f2d8
 # Solution
 
 def analyze_optimization_techniques(base_model: Any, optimized_models: List[Any],

--- a/data/trentorch/perf/compression.py
+++ b/data/trentorch/perf/compression.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'MB_TO_BYTES', 'measure_sparsity', 'magnitude_prune', 'structured_prune',
            'low_rank_approximate', 'KnowledgeDistillation', 'Compressor', 'verify_pruning_works']
 
-# %% ../../solutions/16_compression/compression.ipynb #338354ec
+# %% ../../solutions/16_compression/compression.ipynb #3b568873
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
 # Sequential provides model container with .layers and .parameters()
 
-# %% ../../solutions/16_compression/compression.ipynb #9e8cbda4
+# %% ../../solutions/16_compression/compression.ipynb #6f141be5
 # Solution
 
 def measure_sparsity(model) -> float:
@@ -86,7 +86,7 @@ def measure_sparsity(model) -> float:
     return (zero_params / total_params) * 100.0
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #ea7ca246
+# %% ../../solutions/16_compression/compression.ipynb #4c1b3481
 # Solution
 
 def magnitude_prune(model, sparsity=0.9):
@@ -143,7 +143,7 @@ def magnitude_prune(model, sparsity=0.9):
     return model
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #1bbdff19
+# %% ../../solutions/16_compression/compression.ipynb #92c2404f
 # Solution
 
 def structured_prune(model, prune_ratio=0.5):
@@ -202,7 +202,7 @@ def structured_prune(model, prune_ratio=0.5):
     return model
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #541e078e
+# %% ../../solutions/16_compression/compression.ipynb #9d6673c3
 # Solution
 
 def low_rank_approximate(weight_matrix, rank_ratio=0.5):
@@ -246,7 +246,7 @@ def low_rank_approximate(weight_matrix, rank_ratio=0.5):
     return U_truncated, S_truncated, V_truncated
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #15725e38
+# %% ../../solutions/16_compression/compression.ipynb #02ea8a93
 # Solution
 
 class KnowledgeDistillation:
@@ -365,7 +365,7 @@ class KnowledgeDistillation:
         else:
             return -np.mean(np.sum(labels * np.log(predictions + 1e-8), axis=1))
 
-# %% ../../solutions/16_compression/compression.ipynb #677ef226
+# %% ../../solutions/16_compression/compression.ipynb #637d3419
 class Compressor:
     """
     Complete compression system for milestone use.
@@ -433,7 +433,7 @@ class Compressor:
 # Note: measure_sparsity, magnitude_prune, structured_prune are defined earlier in this module.
 # The Compressor class above delegates to those functions, providing an OOP interface for milestones.
 
-# %% ../../solutions/16_compression/compression.ipynb #ba41baef
+# %% ../../solutions/16_compression/compression.ipynb #78bbea57
 def verify_pruning_works(model, target_sparsity=0.8):
     """
     Verify pruning actually creates zeros using real zero counting.

--- a/data/trentorch/perf/memoization.py
+++ b/data/trentorch/perf/memoization.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'KVCache', 'enable_kv_cache', 'disable_kv_cache']
 
-# %% ../../solutions/18_memoization/memoization.ipynb #78bc3038
+# %% ../../solutions/18_memoization/memoization.ipynb #d5919623
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -31,7 +31,7 @@ from ..core.tensor import Tensor
 _BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 _MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/18_memoization/memoization.ipynb #b66ccb89
+# %% ../../solutions/18_memoization/memoization.ipynb #88e6ddf9
 # Solution
 
 class KVCache:
@@ -320,7 +320,7 @@ class KVCache:
             'total_elements': total_elements
         }
 
-# %% ../../solutions/18_memoization/memoization.ipynb #5f8f585a
+# %% ../../solutions/18_memoization/memoization.ipynb #0bbc5abc
 def _cached_generation_step(x, attention, cache_obj, layer_idx):
     """
     Execute a single cached generation step for one new token.
@@ -401,7 +401,7 @@ def _cached_generation_step(x, attention, cache_obj, layer_idx):
 
     return attention.out_proj.forward(concat_output)
 
-# %% ../../solutions/18_memoization/memoization.ipynb #b8e19a79
+# %% ../../solutions/18_memoization/memoization.ipynb #8dc35ab6
 # Solution
 
 def _create_cache_storage(model):
@@ -468,7 +468,7 @@ def _create_cache_storage(model):
     return cache, head_dim
     ### END SOLUTION
 
-# %% ../../solutions/18_memoization/memoization.ipynb #56bd557d
+# %% ../../solutions/18_memoization/memoization.ipynb #45575072
 # Solution
 
 def _cached_attention_forward(block, x, cache_obj, layer_idx, original_forward):
@@ -525,7 +525,7 @@ def _cached_attention_forward(block, x, cache_obj, layer_idx, original_forward):
     return _cached_generation_step(x, block.attention, cache_obj, layer_idx)
     ### END SOLUTION
 
-# %% ../../solutions/18_memoization/memoization.ipynb #9824a278
+# %% ../../solutions/18_memoization/memoization.ipynb #18601da2
 # Solution
 
 def enable_kv_cache(model):

--- a/data/trentorch/perf/profiling.py
+++ b/data/trentorch/perf/profiling.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'Profiler', 'quick_profile', 'analyze_weight_distribution']
 
-# %% ../../solutions/14_profiling/profiling.ipynb #6efa4197
+# %% ../../solutions/14_profiling/profiling.ipynb #c3b13111
 import sys
 import os
 import time
@@ -38,7 +38,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/14_profiling/profiling.ipynb #91c6368c
+# %% ../../solutions/14_profiling/profiling.ipynb #0b8f2f14
 # Solution
 
 class Profiler:
@@ -658,7 +658,7 @@ class Profiler:
         }
         ### END SOLUTION
 
-# %% ../../solutions/14_profiling/profiling.ipynb #476d5fb0
+# %% ../../solutions/14_profiling/profiling.ipynb #92a774d7
 def quick_profile(model, input_tensor, profiler=None):
     """
     Quick profiling function for immediate insights.
@@ -696,7 +696,7 @@ def quick_profile(model, input_tensor, profiler=None):
 
     return profile
 
-# %% ../../solutions/14_profiling/profiling.ipynb #2422726f
+# %% ../../solutions/14_profiling/profiling.ipynb #3d93c931
 def analyze_weight_distribution(model, percentiles=[10, 25, 50, 75, 90]):
     """
     Analyze weight distribution across layers.

--- a/data/trentorch/perf/quantization.py
+++ b/data/trentorch/perf/quantization.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'INT8_MIN_VALUE', 'INT8_MAX_VALUE', 'INT8_RANGE', 'EPSILON', '
            'MB_TO_BYTES', 'quantize_int8', 'dequantize_int8', 'QuantizedLinear', 'quantize_model', 'Quantizer',
            'verify_quantization_works']
 
-# %% ../../solutions/15_quantization/quantization.ipynb #5701a61e
+# %% ../../solutions/15_quantization/quantization.ipynb #d3337ada
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -46,7 +46,7 @@ MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 if __name__ == "__main__":
     print("Quantization module imports complete")
 
-# %% ../../solutions/15_quantization/quantization.ipynb #c6ecd53e
+# %% ../../solutions/15_quantization/quantization.ipynb #5f70e998
 # Solution
 
 def quantize_int8(tensor: Tensor) -> Tuple[Tensor, float, int]:
@@ -126,7 +126,7 @@ def quantize_int8(tensor: Tensor) -> Tuple[Tensor, float, int]:
     return Tensor(quantized_data), scale, zero_point
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #80a07137
+# %% ../../solutions/15_quantization/quantization.ipynb #ead013f4
 # Solution
 
 def dequantize_int8(q_tensor: Tensor, scale: float, zero_point: int) -> Tensor:
@@ -165,7 +165,7 @@ def dequantize_int8(q_tensor: Tensor, scale: float, zero_point: int) -> Tensor:
     return Tensor(dequantized_data)
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #c42695f0
+# %% ../../solutions/15_quantization/quantization.ipynb #5a705919
 # Solution
 
 class QuantizedLinear:
@@ -343,7 +343,7 @@ class QuantizedLinear:
         }
         ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #16a12392
+# %% ../../solutions/15_quantization/quantization.ipynb #54652ceb
 # Solution
 
 def _collect_layer_inputs(model, layer_index: int, calibration_data: List[Tensor], max_samples: int = 10) -> List[Tensor]:
@@ -386,7 +386,7 @@ def _collect_layer_inputs(model, layer_index: int, calibration_data: List[Tensor
     return sample_inputs
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #90286d71
+# %% ../../solutions/15_quantization/quantization.ipynb #38c8a7d3
 # Solution
 
 def _quantize_single_layer(layer: Linear, calibration_inputs: Optional[List[Tensor]] = None) -> QuantizedLinear:
@@ -426,7 +426,7 @@ def _quantize_single_layer(layer: Linear, calibration_inputs: Optional[List[Tens
     return quantized_layer
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #33704a8a
+# %% ../../solutions/15_quantization/quantization.ipynb #1ff8ecf4
 # Solution
 
 def quantize_model(model, calibration_data: Optional[List[Tensor]] = None) -> None:
@@ -489,7 +489,7 @@ def quantize_model(model, calibration_data: Optional[List[Tensor]] = None) -> No
         )
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #d3586548
+# %% ../../solutions/15_quantization/quantization.ipynb #c234fd88
 class Quantizer:
     """
     Complete quantization system for milestone use.
@@ -571,7 +571,7 @@ class Quantizer:
 # Note: quantize_int8, dequantize_int8, and quantize_model are defined earlier in this module.
 # The Quantizer class above delegates to those functions, providing an OOP interface for milestones.
 
-# %% ../../solutions/15_quantization/quantization.ipynb #ca8dc4ac
+# %% ../../solutions/15_quantization/quantization.ipynb #d31266c6
 def verify_quantization_works(original_model, quantized_model):
     """
     Verify quantization actually reduces memory using real .nbytes measurements.


### PR DESCRIPTION
Reopened from #51 under the correctly-named branch per the new branch naming convention (`docs/CONTRIBUTING.md`: `<github-username>/<feature-name>`). Same commit, no content change.

## What's broken

`autograd.py` patches `Tensor.sum = sum_op`, a version of `sum()` that builds a `SumBackward` node and correctly propagates `requires_grad`. There's no equivalent for `mean()` anywhere in the curriculum, so it silently keeps running module 01's original plain implementation: `np.mean(...)` wrapped in a fresh `Tensor(result)`, with no gradient tracking at all.

```python
t = Tensor([1.0, 2.0, 3.0], requires_grad=True)
out = (t * t).mean()
out.requires_grad  # False
out.backward()
t.grad  # None -- no error, no warning, just silently wrong
```

`sum()` on the identical input correctly returns `requires_grad=True` and backprops. Nothing inside TrenTorch's own losses/layers currently calls `.mean()` (confirmed via a full grep of the exported package), so no internal code path breaks today, but any student who reaches for the natural `.mean()` call in their own training loop, e.g. averaging a batch loss, gets silently zero gradients with no error and no way to know their own code isn't the problem.

## The fix

`mean_op` is built from the already-tracked `sum()` and division rather than a new backward `Function` from scratch, since both are already verified correct elsewhere. Handles `axis=None`, an int axis, and a tuple axis the same way `np.mean` does. Wired in as `Tensor.mean = mean_op` right alongside the existing `Tensor.sum = sum_op` line.

## Verification

- Reproduced the bug directly, confirmed the fix resolves it with the exact expected analytical value (`2x/n`)
- 20-trial finite-difference check against random inputs, all matched within 5e-3 tolerance
- Full local suite: 897 passed / 2 failed, identical to the pre-fix baseline. Both remaining failures are pre-existing and unrelated (this dev machine's local `pip` absence, and a known test-isolation gap already tracked in `docs/testing-strategy.md`)
- `ruff check` / `ruff format --check` clean
- The edit to `data/src/06_autograd/06_autograd.py` is confined entirely inside the existing, already-fully-implemented `enable_autograd()` function (no `# %%` cell markers touched), verified via diff against HEAD before and after