### PR TITLE
Fix Tensor.max() silently dropping gradients

### DIFF
--- a/data/src/06_autograd/06_autograd.py
+++ b/data/src/06_autograd/06_autograd.py
@@ -3914,6 +3914,57 @@ def enable_autograd(quiet=False):
 
         return self.sum(axis=axis, keepdims=keepdims) / n
 
+    class MaxBackward(Function):
+        """
+        Gradient computation for tensor max.
+
+        Unlike sum(), max() isn't a smooth combination of already-tracked
+        ops, so it needs its own Function rather than being built from
+        others the way mean() was. Only the element(s) equal to the
+        maximum receive gradient: perturbing any other element by a
+        small enough epsilon doesn't change the max, so its local
+        gradient is exactly zero. Ties split the incoming gradient
+        equally among themselves.
+        """
+
+        def __init__(self, tensor, axis=None, keepdims=False):
+            super().__init__(tensor)
+            self.axis = axis
+            self.keepdims = keepdims
+
+        def apply(self, grad_output):
+            tensor, = self.saved_tensors
+
+            if isinstance(tensor, Tensor) and tensor.requires_grad:
+                max_vals = np.max(tensor.data, axis=self.axis, keepdims=True)
+                mask = (tensor.data == max_vals).astype(tensor.data.dtype)
+                mask /= mask.sum(axis=self.axis, keepdims=True)
+
+                if self.axis is not None and not self.keepdims:
+                    grad_output = np.expand_dims(grad_output, axis=self.axis)
+
+                return mask * grad_output,
+            return None,
+
+    def max_op(self, axis=None, keepdims=False):
+        """
+        Max operation with gradient tracking.
+
+        Creates a new max method that builds computation graphs
+        when requires_grad=True, mirroring sum_op's structure but
+        routing gradient only through the argmax element(s).
+        """
+        _ensure_grad_attrs(self)
+
+        result_data = np.max(self.data, axis=axis, keepdims=keepdims)
+        result = Tensor(result_data)
+
+        if _get_requires_grad(self):
+            result.requires_grad = True
+            result._grad_fn = MaxBackward(self, axis=axis, keepdims=keepdims)
+
+        return result
+
     def backward(self, gradient=None, retain_graph=False):
         """
         Compute gradients via backpropagation.
@@ -4031,6 +4082,7 @@ def enable_autograd(quiet=False):
     Tensor.reshape = tracked_reshape
     Tensor.sum = sum_op
     Tensor.mean = mean_op
+    Tensor.max = max_op
     Tensor.backward = backward
     Tensor.zero_grad = zero_grad
 

--- a/data/trentorch/core/activations.py
+++ b/data/trentorch/core/activations.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'TOLERANCE', 'Sigmoid', 'ReLU', 'Tanh', 'GELU', 'Softmax']
 
-# %% ../../solutions/02_activations/activations.ipynb #e08bdf98
+# %% ../../solutions/02_activations/activations.ipynb #21251c0d
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -32,7 +32,7 @@ TOLERANCE = 1e-10  # Small tolerance for floating-point comparisons in tests
 # Export only activation classes
 __all__ = ['Sigmoid', 'ReLU', 'Tanh', 'GELU', 'Softmax']
 
-# %% ../../solutions/02_activations/activations.ipynb #05b71c74
+# %% ../../solutions/02_activations/activations.ipynb #f757edeb
 # Solution
 
 class Sigmoid:
@@ -86,7 +86,7 @@ class Sigmoid:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #24d9353f
+# %% ../../solutions/02_activations/activations.ipynb #42344e38
 # Solution
 
 class ReLU:
@@ -130,7 +130,7 @@ class ReLU:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #0e1b7a42
+# %% ../../solutions/02_activations/activations.ipynb #6d4fa19d
 # Solution
 
 class Tanh:
@@ -174,7 +174,7 @@ class Tanh:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #ed4e48e6
+# %% ../../solutions/02_activations/activations.ipynb #dfd74513
 # Solution
 
 class GELU:
@@ -218,7 +218,7 @@ class GELU:
         """Allows the activation to be called like a function."""
         return self.forward(x)
 
-# %% ../../solutions/02_activations/activations.ipynb #77cec5fd
+# %% ../../solutions/02_activations/activations.ipynb #8b209069
 # Solution
 
 class Softmax:

--- a/data/trentorch/core/attention.py
+++ b/data/trentorch/core/attention.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'MASK_VALUE', 'scaled_dot_product_attention', 'MultiHeadAttention']
 
-# %% ../../solutions/12_attention/attention.ipynb #8f9164ab
+# %% ../../solutions/12_attention/attention.ipynb #31b4f4c7
 #| default_exp core.attention
 #| export
 
-# %% ../../solutions/12_attention/attention.ipynb #25b0ceab
+# %% ../../solutions/12_attention/attention.ipynb #62087108
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ from .activations import Softmax
 # Constants for attention computation
 MASK_VALUE = -1e9  # Large negative value used for attention masking (becomes ~0 after softmax)
 
-# %% ../../solutions/12_attention/attention.ipynb #6c4de1f7
+# %% ../../solutions/12_attention/attention.ipynb #971b096b
 # Solution
 
 def _compute_attention_scores(Q: Tensor, K: Tensor) -> Tensor:
@@ -62,7 +62,7 @@ def _compute_attention_scores(Q: Tensor, K: Tensor) -> Tensor:
     return Q.matmul(K_t)
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #45e8e742
+# %% ../../solutions/12_attention/attention.ipynb #4449b6ed
 # Solution
 
 def _scale_scores(scores: Tensor, d_model: int) -> Tensor:
@@ -86,7 +86,7 @@ def _scale_scores(scores: Tensor, d_model: int) -> Tensor:
     return scores * scale_factor
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #00b2461e
+# %% ../../solutions/12_attention/attention.ipynb #0d88ce4e
 # Solution
 
 def _apply_mask(scores: Tensor, mask: Tensor) -> Tensor:
@@ -111,7 +111,7 @@ def _apply_mask(scores: Tensor, mask: Tensor) -> Tensor:
     return scores + adder
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #d6df72a3
+# %% ../../solutions/12_attention/attention.ipynb #936a741f
 # Solution
 
 def scaled_dot_product_attention(Q: Tensor, K: Tensor, V: Tensor, mask: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
@@ -162,7 +162,7 @@ def scaled_dot_product_attention(Q: Tensor, K: Tensor, V: Tensor, mask: Optional
     return output, attention_weights
     ### END SOLUTION
 
-# %% ../../solutions/12_attention/attention.ipynb #ff825e58
+# %% ../../solutions/12_attention/attention.ipynb #7c8f3e04
 # Solution
 
 class MultiHeadAttention:

--- a/data/trentorch/core/autograd.py
+++ b/data/trentorch/core/autograd.py
@@ -20,7 +20,7 @@ __all__ = ['rng', 'EPSILON', 'Function', 'AddBackward', 'MulBackward', 'SubBackw
            'SigmoidBackward', 'TanhBackward', 'SoftmaxBackward', 'GELUBackward', 'MSEBackward', 'BCEBackward',
            'CrossEntropyBackward', 'is_grad_enabled', 'no_grad', 'enable_autograd']
 
-# %% ../../solutions/06_autograd/autograd.ipynb #510b242f
+# %% ../../solutions/06_autograd/autograd.ipynb #d27c9474
 import numpy as np
 rng = np.random.default_rng(7)
 from typing import Optional, List, Tuple
@@ -32,7 +32,7 @@ from .tensor import Tensor
 # Constants for numerical differentiation
 EPSILON = 1e-7  # Small perturbation for numerical gradient computation
 
-# %% ../../solutions/06_autograd/autograd.ipynb #6abe1ad5
+# %% ../../solutions/06_autograd/autograd.ipynb #2f5093c1
 class Function:
     """
     Base class for differentiable operations.
@@ -76,7 +76,7 @@ class Function:
         """
         raise NotImplementedError("Each Function must implement apply() method")
 
-# %% ../../solutions/06_autograd/autograd.ipynb #fd699e4f
+# %% ../../solutions/06_autograd/autograd.ipynb #8bd793a5
 # Solution
 
 def _reduce_broadcast_grad(grad, original_shape):
@@ -117,7 +117,7 @@ def _reduce_broadcast_grad(grad, original_shape):
     return grad
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #fa059962
+# %% ../../solutions/06_autograd/autograd.ipynb #38411d58
 # Solution
 
 class AddBackward(Function):
@@ -200,7 +200,7 @@ class AddBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #735d0ffd
+# %% ../../solutions/06_autograd/autograd.ipynb #95f674c2
 # Solution
 
 class MulBackward(Function):
@@ -280,7 +280,7 @@ class MulBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #e0e3c2ae
+# %% ../../solutions/06_autograd/autograd.ipynb #aae84231
 # Solution
 
 class SubBackward(Function):
@@ -340,7 +340,7 @@ class SubBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #d27e9d65
+# %% ../../solutions/06_autograd/autograd.ipynb #be85f276
 # Solution
 
 class DivBackward(Function):
@@ -409,7 +409,7 @@ class DivBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #9df2cbde
+# %% ../../solutions/06_autograd/autograd.ipynb #af7e6a4d
 # Solution
 
 class MatmulBackward(Function):
@@ -500,7 +500,7 @@ class MatmulBackward(Function):
         return grad_a, grad_b
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #cd0eeb47
+# %% ../../solutions/06_autograd/autograd.ipynb #2a80d903
 # Solution
 
 class TransposeBackward(Function):
@@ -588,7 +588,7 @@ class TransposeBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #a2d8edb7
+# %% ../../solutions/06_autograd/autograd.ipynb #abe39d73
 # Solution
 
 class PermuteBackward(Function):
@@ -659,7 +659,7 @@ class PermuteBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #b232addf
+# %% ../../solutions/06_autograd/autograd.ipynb #3b703a9c
 # Solution
 
 class SliceBackward(Function):
@@ -751,7 +751,7 @@ class SliceBackward(Function):
         return (grad_input,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #902158d8
+# %% ../../solutions/06_autograd/autograd.ipynb #0bdea66c
 # Solution
 
 class ReshapeBackward(Function):
@@ -824,7 +824,7 @@ class ReshapeBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #6cc1d521
+# %% ../../solutions/06_autograd/autograd.ipynb #3d3fa2db
 # Solution
 
 class SumBackward(Function):
@@ -892,7 +892,7 @@ class SumBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #82ba7642
+# %% ../../solutions/06_autograd/autograd.ipynb #9d70ccd9
 # Solution
 
 class ReLUBackward(Function):
@@ -943,7 +943,7 @@ class ReLUBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #007fb8e7
+# %% ../../solutions/06_autograd/autograd.ipynb #cbce0458
 # Solution
 
 class SigmoidBackward(Function):
@@ -1002,7 +1002,7 @@ class SigmoidBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #cef069f8
+# %% ../../solutions/06_autograd/autograd.ipynb #534edc40
 # Solution
 
 class TanhBackward(Function):
@@ -1061,7 +1061,7 @@ class TanhBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #55e1807d
+# %% ../../solutions/06_autograd/autograd.ipynb #33ba1e9b
 # Solution
 
 class SoftmaxBackward(Function):
@@ -1137,7 +1137,7 @@ class SoftmaxBackward(Function):
         return (None,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #bc3fce5c
+# %% ../../solutions/06_autograd/autograd.ipynb #678e58b3
 # Solution
 
 class GELUBackward(Function):
@@ -1195,7 +1195,7 @@ class GELUBackward(Function):
         return (None,)
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #b3452e78
+# %% ../../solutions/06_autograd/autograd.ipynb #5938d777
 # Solution
 
 class MSEBackward(Function):
@@ -1250,7 +1250,7 @@ class MSEBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #7bb9869c
+# %% ../../solutions/06_autograd/autograd.ipynb #415af936
 # Solution
 
 class BCEBackward(Function):
@@ -1309,7 +1309,7 @@ class BCEBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #bfb55676
+# %% ../../solutions/06_autograd/autograd.ipynb #975e9670
 # Solution
 
 def _stable_softmax(logits_data):
@@ -1346,7 +1346,7 @@ def _stable_softmax(logits_data):
     return exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #2f923bfe
+# %% ../../solutions/06_autograd/autograd.ipynb #3782aadb
 # Solution
 
 def _one_hot_encode(targets, batch_size, num_classes):
@@ -1381,7 +1381,7 @@ def _one_hot_encode(targets, batch_size, num_classes):
     return one_hot
     ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #2d1a5c74
+# %% ../../solutions/06_autograd/autograd.ipynb #441109a3
 # Solution
 
 class CrossEntropyBackward(Function):
@@ -1453,7 +1453,7 @@ class CrossEntropyBackward(Function):
         return None,
         ### END SOLUTION
 
-# %% ../../solutions/06_autograd/autograd.ipynb #38b5f36e
+# %% ../../solutions/06_autograd/autograd.ipynb #78722fad
 # ===== Global Gradient Tracking Flag =====
 # Why this exists: During inference or parameter updates, we don't need to build
 # computation graphs. Skipping graph construction saves memory and time.
@@ -1518,7 +1518,7 @@ class no_grad:
         _GRAD_TRACKING_ENABLED = self._prev_state
         return False  # Don't suppress exceptions
 
-# %% ../../solutions/06_autograd/autograd.ipynb #90369612
+# %% ../../solutions/06_autograd/autograd.ipynb #338c2652
 def enable_autograd(quiet=False):
     """
     Enable gradient tracking for all Tensor operations.
@@ -1847,6 +1847,57 @@ def enable_autograd(quiet=False):
 
         return self.sum(axis=axis, keepdims=keepdims) / n
 
+    class MaxBackward(Function):
+        """
+        Gradient computation for tensor max.
+
+        Unlike sum(), max() isn't a smooth combination of already-tracked
+        ops, so it needs its own Function rather than being built from
+        others the way mean() was. Only the element(s) equal to the
+        maximum receive gradient: perturbing any other element by a
+        small enough epsilon doesn't change the max, so its local
+        gradient is exactly zero. Ties split the incoming gradient
+        equally among themselves.
+        """
+
+        def __init__(self, tensor, axis=None, keepdims=False):
+            super().__init__(tensor)
+            self.axis = axis
+            self.keepdims = keepdims
+
+        def apply(self, grad_output):
+            tensor, = self.saved_tensors
+
+            if isinstance(tensor, Tensor) and tensor.requires_grad:
+                max_vals = np.max(tensor.data, axis=self.axis, keepdims=True)
+                mask = (tensor.data == max_vals).astype(tensor.data.dtype)
+                mask /= mask.sum(axis=self.axis, keepdims=True)
+
+                if self.axis is not None and not self.keepdims:
+                    grad_output = np.expand_dims(grad_output, axis=self.axis)
+
+                return mask * grad_output,
+            return None,
+
+    def max_op(self, axis=None, keepdims=False):
+        """
+        Max operation with gradient tracking.
+
+        Creates a new max method that builds computation graphs
+        when requires_grad=True, mirroring sum_op's structure but
+        routing gradient only through the argmax element(s).
+        """
+        _ensure_grad_attrs(self)
+
+        result_data = np.max(self.data, axis=axis, keepdims=keepdims)
+        result = Tensor(result_data)
+
+        if _get_requires_grad(self):
+            result.requires_grad = True
+            result._grad_fn = MaxBackward(self, axis=axis, keepdims=keepdims)
+
+        return result
+
     def backward(self, gradient=None, retain_graph=False):
         """
         Compute gradients via backpropagation.
@@ -1964,6 +2015,7 @@ def enable_autograd(quiet=False):
     Tensor.reshape = tracked_reshape
     Tensor.sum = sum_op
     Tensor.mean = mean_op
+    Tensor.max = max_op
     Tensor.backward = backward
     Tensor.zero_grad = zero_grad
 

--- a/data/trentorch/core/dataloader.py
+++ b/data/trentorch/core/dataloader.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'Dataset', 'TensorDataset', 'DataLoader', 'RandomHorizontalFlip', 'RandomCrop', 'Compose']
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #f8ff5de2
+# %% ../../solutions/05_dataloader/dataloader.ipynb #3fb5c2df
 #| default_exp core.dataloader
 #| export
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #ed9e5e41
+# %% ../../solutions/05_dataloader/dataloader.ipynb #36b3c993
 # Essential imports for data loading
 import random
 import sys
@@ -35,7 +35,7 @@ rng = np.random.default_rng(7)
 # Import real Tensor class from trentorch package
 from .tensor import Tensor
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #084e2b5a
+# %% ../../solutions/05_dataloader/dataloader.ipynb #b3b6dd1f
 # Solution
 
 class Dataset(ABC):
@@ -90,7 +90,7 @@ class Dataset(ABC):
         pass
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #4c526e7c
+# %% ../../solutions/05_dataloader/dataloader.ipynb #293f9bc9
 # Solution
 
 class TensorDataset(Dataset):
@@ -206,7 +206,7 @@ class TensorDataset(Dataset):
         return tuple(Tensor(tensor.data[idx]) for tensor in self.tensors)
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #da85fae7
+# %% ../../solutions/05_dataloader/dataloader.ipynb #7a1788bd
 # Solution
 
 class DataLoader:
@@ -363,7 +363,7 @@ class DataLoader:
         return tuple(batched_tensors)
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #ae80ce11
+# %% ../../solutions/05_dataloader/dataloader.ipynb #a6dcc3a1
 # Solution
 
 class RandomHorizontalFlip:
@@ -461,7 +461,7 @@ class RandomHorizontalFlip:
         return x
         ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #864bc84f
+# %% ../../solutions/05_dataloader/dataloader.ipynb #6b203204
 # Solution
 
 def _pad_image(data, padding):
@@ -512,7 +512,7 @@ def _pad_image(data, padding):
         )
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #f1076cb0
+# %% ../../solutions/05_dataloader/dataloader.ipynb #4dfe7e2c
 # Solution
 
 def _random_crop_region(padded_h, padded_w, target_h, target_w):
@@ -538,7 +538,7 @@ def _random_crop_region(padded_h, padded_w, target_h, target_w):
     return top, left
     ### END SOLUTION
 
-# %% ../../solutions/05_dataloader/dataloader.ipynb #bddc4364
+# %% ../../solutions/05_dataloader/dataloader.ipynb #5342a3ba
 # Solution
 
 class RandomCrop:

--- a/data/trentorch/core/embeddings.py
+++ b/data/trentorch/core/embeddings.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'EmbeddingBackward', 'Embedding', 'PositionalEncoding',
            'create_sinusoidal_embeddings', 'EmbeddingLayer', 'emblayer_forward']
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #3236e845
+# %% ../../solutions/11_embeddings/embeddings.ipynb #722b4b8f
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #04373dc6
+# %% ../../solutions/11_embeddings/embeddings.ipynb #1bb9bdb2
 # Solution
 
 class EmbeddingBackward(Function):
@@ -118,7 +118,7 @@ class EmbeddingBackward(Function):
         return (grad_weight,)
         ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #58a69725
+# %% ../../solutions/11_embeddings/embeddings.ipynb #6c81b324
 # Solution
 
 class Embedding:
@@ -219,7 +219,7 @@ class Embedding:
     def __repr__(self):
         return f"Embedding(vocab_size={self.vocab_size}, embed_dim={self.embed_dim})"
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #cb580b7a
+# %% ../../solutions/11_embeddings/embeddings.ipynb #dabba211
 # Solution
 
 class PositionalEncoding:
@@ -341,7 +341,7 @@ class PositionalEncoding:
     def __repr__(self):
         return f"PositionalEncoding(max_seq_len={self.max_seq_len}, embed_dim={self.embed_dim})"
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #3ab9a2ce
+# %% ../../solutions/11_embeddings/embeddings.ipynb #b6c66394
 # Solution
 
 def _compute_sinusoidal_table(max_len: int, embed_dim: int) -> np.ndarray:
@@ -401,7 +401,7 @@ def _compute_sinusoidal_table(max_len: int, embed_dim: int) -> np.ndarray:
     return pe
     ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #45227b9e
+# %% ../../solutions/11_embeddings/embeddings.ipynb #fd9cb702
 # Solution
 
 def create_sinusoidal_embeddings(max_seq_len: int, embed_dim: int) -> Tensor:
@@ -434,7 +434,7 @@ def create_sinusoidal_embeddings(max_seq_len: int, embed_dim: int) -> Tensor:
     return Tensor(pe)
     ### END SOLUTION
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #32a3bf7c
+# %% ../../solutions/11_embeddings/embeddings.ipynb #3f658ed5
 # Solution
 
 class EmbeddingLayer:
@@ -520,7 +520,7 @@ class EmbeddingLayer:
                 f"embed_dim={self.embed_dim}, "
                 f"pos_encoding='{self.pos_encoding_type}')")
 
-# %% ../../solutions/11_embeddings/embeddings.ipynb #e11792c1
+# %% ../../solutions/11_embeddings/embeddings.ipynb #0d4a85fa
 # Solution
 
 # Continue the EmbeddingLayer class with forward and utility methods

--- a/data/trentorch/core/layers.py
+++ b/data/trentorch/core/layers.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'INIT_SCALE_FACTOR', 'HE_SCALE_FACTOR', 'DROPOUT_MIN_PROB', 'DROPOUT_MAX_PROB', 'Layer', 'Linear', 'Dropout',
            'Sequential']
 
-# %% ../../solutions/03_layers/layers.ipynb #42de637e
+# %% ../../solutions/03_layers/layers.ipynb #7ea222f8
 import os
 import numpy as np
 # Module-level RNG is seeded so Linear weight init is deterministic by default.
@@ -42,7 +42,7 @@ HE_SCALE_FACTOR = 2.0  # He initialization uses sqrt(2/fan_in) for ReLU
 DROPOUT_MIN_PROB = 0.0  # Minimum dropout probability (no dropout)
 DROPOUT_MAX_PROB = 1.0  # Maximum dropout probability (drop everything)
 
-# %% ../../solutions/03_layers/layers.ipynb #cc8760d2
+# %% ../../solutions/03_layers/layers.ipynb #cf66612a
 class Layer:
     """
     Base class for all neural network layers.
@@ -91,7 +91,7 @@ class Layer:
         """String representation of the layer."""
         return f"{self.__class__.__name__}()"
 
-# %% ../../solutions/03_layers/layers.ipynb #0cd903e5
+# %% ../../solutions/03_layers/layers.ipynb #5e079870
 # Solution
 
 class Linear(Layer):
@@ -213,7 +213,7 @@ class Linear(Layer):
         bias_str = f", bias={self.bias is not None}"
         return f"Linear(in_features={self.in_features}, out_features={self.out_features}{bias_str})"
 
-# %% ../../solutions/03_layers/layers.ipynb #0c16d987
+# %% ../../solutions/03_layers/layers.ipynb #0a12e400
 # Solution
 
 class Dropout(Layer):
@@ -382,7 +382,7 @@ class Dropout(Layer):
     def __repr__(self):
         return f"Dropout(p={self.p})"
 
-# %% ../../solutions/03_layers/layers.ipynb #66f3a59c
+# %% ../../solutions/03_layers/layers.ipynb #fe2d52ff
 class Sequential:
     """
     Container that chains layers together sequentially.

--- a/data/trentorch/core/losses.py
+++ b/data/trentorch/core/losses.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'EPSILON', 'log_softmax', 'MSELoss', 'CrossEntropyLoss', 'BinaryCrossEntropyLoss']
 
-# %% ../../solutions/04_losses/losses.ipynb #2aaba77e
+# %% ../../solutions/04_losses/losses.ipynb #9ad274f6
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -31,7 +31,7 @@ from .layers import Linear
 # Constants for numerical stability
 EPSILON = 1e-7  # Small value to prevent log(0) and numerical instability
 
-# %% ../../solutions/04_losses/losses.ipynb #6e68138a
+# %% ../../solutions/04_losses/losses.ipynb #06ba2855
 # Solution
 
 def log_softmax(x: Tensor, dim: int = -1) -> Tensor:
@@ -70,7 +70,7 @@ def log_softmax(x: Tensor, dim: int = -1) -> Tensor:
     return Tensor(result)
     ### END SOLUTION
 
-# %% ../../solutions/04_losses/losses.ipynb #52413146
+# %% ../../solutions/04_losses/losses.ipynb #8ecd5dc0
 # Solution
 
 class MSELoss:
@@ -129,7 +129,7 @@ class MSELoss:
         """
         pass
 
-# %% ../../solutions/04_losses/losses.ipynb #3a405bf8
+# %% ../../solutions/04_losses/losses.ipynb #9cca1147
 # Solution
 
 class CrossEntropyLoss:
@@ -192,7 +192,7 @@ class CrossEntropyLoss:
         """
         pass
 
-# %% ../../solutions/04_losses/losses.ipynb #c1866ad3
+# %% ../../solutions/04_losses/losses.ipynb #2646f1c4
 # Solution
 
 class BinaryCrossEntropyLoss:

--- a/data/trentorch/core/optimizers.py
+++ b/data/trentorch/core/optimizers.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'DEFAULT_LEARNING_RATE_SGD', 'DEFAULT_LEARNING_RATE_ADAM', 'DEFAULT_MOMENTUM', 'DEFAULT_BETA1', 'DEFAULT_BETA2',
            'DEFAULT_EPS', 'DEFAULT_WEIGHT_DECAY_ADAMW', 'Optimizer', 'SGD', 'Adam', 'AdamW']
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #110ce474
+# %% ../../solutions/07_optimizers/optimizers.ipynb #8eb84073
 import numpy as np
 rng = np.random.default_rng(7)
 from typing import List, Union, Optional, Dict, Any
@@ -40,7 +40,7 @@ DEFAULT_BETA2 = 0.999  # Second moment decay rate for Adam
 DEFAULT_EPS = 1e-8  # Small epsilon for numerical stability in Adam
 DEFAULT_WEIGHT_DECAY_ADAMW = 0.01  # Default weight decay for AdamW
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #7e617b27
+# %% ../../solutions/07_optimizers/optimizers.ipynb #2b9f676c
 # Solution
 
 class Optimizer:
@@ -123,7 +123,7 @@ class Optimizer:
             f"                  param.data -= self.lr * param.grad.data"
         )
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #977e58bc
+# %% ../../solutions/07_optimizers/optimizers.ipynb #cddfe3bd
 # Solution
 
 class _ExtractGradientMixin:
@@ -162,7 +162,7 @@ class _ExtractGradientMixin:
 # Attach _extract_gradient to Optimizer so all subclasses inherit it
 Optimizer._extract_gradient = _ExtractGradientMixin._extract_gradient
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #dcb34e66
+# %% ../../solutions/07_optimizers/optimizers.ipynb #6ad011b1
 # Solution
 
 class SGD(Optimizer):
@@ -328,7 +328,7 @@ class SGD(Optimizer):
         self.step_count += 1
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #bf77454a
+# %% ../../solutions/07_optimizers/optimizers.ipynb #79125871
 # Solution
 
 class Adam(Optimizer):
@@ -373,7 +373,7 @@ class Adam(Optimizer):
         self.v_buffers = [None for _ in self.params]  # Second moment (variance)
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #fdaae07c
+# %% ../../solutions/07_optimizers/optimizers.ipynb #87d2aa9a
 # Solution
 
 class _AdamUpdateMomentsMixin:
@@ -430,7 +430,7 @@ class _AdamUpdateMomentsMixin:
 # Attach _update_moments to Adam
 Adam._update_moments = _AdamUpdateMomentsMixin._update_moments
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #f4aee6b6
+# %% ../../solutions/07_optimizers/optimizers.ipynb #9513c76f
 # Solution
 
 class _AdamStepMixin:
@@ -482,7 +482,7 @@ class _AdamStepMixin:
 # Attach step to Adam
 Adam.step = _AdamStepMixin.step
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #31d1ceb8
+# %% ../../solutions/07_optimizers/optimizers.ipynb #58694057
 # Solution
 
 class AdamW(Optimizer):
@@ -525,7 +525,7 @@ class AdamW(Optimizer):
         self.v_buffers = [None for _ in self.params]
         ### END SOLUTION
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #275284a3
+# %% ../../solutions/07_optimizers/optimizers.ipynb #a8d8fd55
 # Solution
 
 class _AdamWUpdateMomentsMixin:
@@ -578,7 +578,7 @@ class _AdamWUpdateMomentsMixin:
 # Attach _update_moments to AdamW
 AdamW._update_moments = _AdamWUpdateMomentsMixin._update_moments
 
-# %% ../../solutions/07_optimizers/optimizers.ipynb #178150c8
+# %% ../../solutions/07_optimizers/optimizers.ipynb #8b7c51a0
 # Solution
 
 class _AdamWStepMixin:

--- a/data/trentorch/core/spatial.py
+++ b/data/trentorch/core/spatial.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'DEFAULT_KERNEL_SIZE', 'DEFAULT_STRIDE', 'DEFAULT_PADDING', 'B
            'validate_4d_input', 'Conv2dBackward', 'Conv2d', 'MaxPool2dBackward', 'MaxPool2d', 'AvgPool2dBackward',
            'AvgPool2d', 'BatchNorm2d', 'SimpleCNN']
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #a364489e
+# %% ../../solutions/09_convolutions/convolutions.ipynb #08e04b27
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -41,7 +41,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #e22ea2fa
+# %% ../../solutions/09_convolutions/convolutions.ipynb #a2d01f2d
 def validate_4d_input(x, layer_name):
     """
     Validate that input tensor is 4D (batch, channels, height, width).
@@ -81,7 +81,7 @@ def validate_4d_input(x, layer_name):
             f"  Reshape your input to 4D with the correct dimensions"
         )
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #7597ea08
+# %% ../../solutions/09_convolutions/convolutions.ipynb #d48ca67d
 # Solution
 
 class Conv2dBackward(Function):
@@ -436,7 +436,7 @@ class Conv2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #413408c9
+# %% ../../solutions/09_convolutions/convolutions.ipynb #f56b49e4
 # Solution
 
 class MaxPool2dBackward(Function):
@@ -690,7 +690,7 @@ class MaxPool2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #68cf3462
+# %% ../../solutions/09_convolutions/convolutions.ipynb #2c0990e7
 # Solution
 
 class AvgPool2dBackward(Function):
@@ -933,7 +933,7 @@ class AvgPool2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #8b87bbaa
+# %% ../../solutions/09_convolutions/convolutions.ipynb #a33a4dae
 # Solution
 
 class BatchNorm2d:
@@ -1140,7 +1140,7 @@ class BatchNorm2d:
         """Enable model(x) syntax."""
         return self.forward(x)
 
-# %% ../../solutions/09_convolutions/convolutions.ipynb #8c91a19e
+# %% ../../solutions/09_convolutions/convolutions.ipynb #ed68e473
 # Solution
 
 class SimpleCNN:

--- a/data/trentorch/core/tensor.py
+++ b/data/trentorch/core/tensor.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'Tensor']
 
-# %% ../../solutions/01_tensor/tensor.ipynb #45223d5e
+# %% ../../solutions/01_tensor/tensor.ipynb #1f0c1c91
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -27,7 +27,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/01_tensor/tensor.ipynb #f00ee192
+# %% ../../solutions/01_tensor/tensor.ipynb #5e174ad0
 # Solution
 
 class Tensor:

--- a/data/trentorch/core/tokenization.py
+++ b/data/trentorch/core/tokenization.py
@@ -18,7 +18,7 @@
 __all__ = ['KB_TO_BYTES', 'Tokenizer', 'CharTokenizer', 'BPETokenizer', 'create_tokenizer', 'tokenize_dataset',
            'analyze_tokenization']
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #a89e3f00
+# %% ../../solutions/10_tokenization/tokenization.ipynb #38b96d5c
 from collections import Counter
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -28,7 +28,7 @@ import numpy as np
 # Constants for memory calculations
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #1efede9e
+# %% ../../solutions/10_tokenization/tokenization.ipynb #a0015d13
 # Solution
 
 class Tokenizer:
@@ -92,7 +92,7 @@ class Tokenizer:
         )
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #62fd4534
+# %% ../../solutions/10_tokenization/tokenization.ipynb #1f8fc424
 # Solution
 
 class CharTokenizer(Tokenizer):
@@ -217,7 +217,7 @@ class CharTokenizer(Tokenizer):
         return ''.join(chars)
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #973b5a18
+# %% ../../solutions/10_tokenization/tokenization.ipynb #55bb3e40
 # Solution
 
 def _count_byte_pairs(word_tokens: Dict[str, List[str]], word_freq: Counter) -> Counter:
@@ -257,7 +257,7 @@ def _count_byte_pairs(word_tokens: Dict[str, List[str]], word_freq: Counter) -> 
     return pair_counts
     ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #abd09df0
+# %% ../../solutions/10_tokenization/tokenization.ipynb #a6e8971e
 # Solution
 
 def _merge_pair(word_tokens: Dict[str, List[str]], pair: Tuple[str, str]) -> str:
@@ -311,7 +311,7 @@ def _merge_pair(word_tokens: Dict[str, List[str]], pair: Tuple[str, str]) -> str
     return merged_token
     ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #ceb0d1c6
+# %% ../../solutions/10_tokenization/tokenization.ipynb #f054658a
 # Solution
 
 class BPETokenizer(Tokenizer):
@@ -600,7 +600,7 @@ class BPETokenizer(Tokenizer):
         return text
         ### END SOLUTION
 
-# %% ../../solutions/10_tokenization/tokenization.ipynb #441db6c1
+# %% ../../solutions/10_tokenization/tokenization.ipynb #3a566ed8
 # Solution
 
 def create_tokenizer(strategy: str = "char", vocab_size: int = 1000, corpus: List[str] = None) -> Tokenizer:

--- a/data/trentorch/core/training.py
+++ b/data/trentorch/core/training.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'DEFAULT_MAX_LR', 'DEFAULT_MIN_LR', 'DEFAULT_TOTAL_EPOCHS', 'C
            'trainer_init', 'trainer_train_epoch', 'trainer_evaluate', 'trainer_save_checkpoint',
            'trainer_load_checkpoint']
 
-# %% ../../solutions/08_training/training.ipynb #c7c2f6d0
+# %% ../../solutions/08_training/training.ipynb #0c9365f5
 import numpy as np
 rng = np.random.default_rng(7)
 import pickle
@@ -44,7 +44,7 @@ DEFAULT_MAX_LR = 0.1  # Default maximum learning rate for cosine schedule
 DEFAULT_MIN_LR = 0.01  # Default minimum learning rate for cosine schedule
 DEFAULT_TOTAL_EPOCHS = 100  # Default total epochs for learning rate schedule
 
-# %% ../../solutions/08_training/training.ipynb #629ede31
+# %% ../../solutions/08_training/training.ipynb #f619d280
 # Solution
 
 class CosineSchedule:
@@ -85,7 +85,7 @@ class CosineSchedule:
         return self.min_lr + (self.max_lr - self.min_lr) * cosine_factor
     ### END SOLUTION
 
-# %% ../../solutions/08_training/training.ipynb #408b8653
+# %% ../../solutions/08_training/training.ipynb #b0e9bee2
 # Solution
 
 def clip_grad_norm(parameters: List, max_norm: float = 1.0) -> float:
@@ -148,7 +148,7 @@ def clip_grad_norm(parameters: List, max_norm: float = 1.0) -> float:
     return float(total_norm)
     ### END SOLUTION
 
-# %% ../../solutions/08_training/training.ipynb #7231d068
+# %% ../../solutions/08_training/training.ipynb #9b1e0d41
 class Trainer:
     """
     Complete training orchestrator for neural networks.
@@ -210,7 +210,7 @@ class Trainer:
             if hasattr(self.scheduler, key):
                 setattr(self.scheduler, key, value)
 
-# %% ../../solutions/08_training/training.ipynb #e60ffa8b
+# %% ../../solutions/08_training/training.ipynb #d7482933
 # Solution
 
 def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm=None):
@@ -272,7 +272,7 @@ def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm
 
 Trainer.__init__ = trainer_init
 
-# %% ../../solutions/08_training/training.ipynb #16182b87
+# %% ../../solutions/08_training/training.ipynb #2aee189d
 # Solution
 
 def _trainer_process_batch(self, inputs, targets, accumulation_steps):
@@ -314,7 +314,7 @@ def _trainer_process_batch(self, inputs, targets, accumulation_steps):
 
 Trainer._process_batch = _trainer_process_batch
 
-# %% ../../solutions/08_training/training.ipynb #40eea921
+# %% ../../solutions/08_training/training.ipynb #37415228
 # Solution
 
 def _trainer_optimizer_update(self):
@@ -339,7 +339,7 @@ def _trainer_optimizer_update(self):
 
 Trainer._optimizer_update = _trainer_optimizer_update
 
-# %% ../../solutions/08_training/training.ipynb #b9ffab9a
+# %% ../../solutions/08_training/training.ipynb #cd62da71
 # Solution
 
 def trainer_train_epoch(self, dataloader, accumulation_steps=1):
@@ -404,7 +404,7 @@ def trainer_train_epoch(self, dataloader, accumulation_steps=1):
 
 Trainer.train_epoch = trainer_train_epoch
 
-# %% ../../solutions/08_training/training.ipynb #2a6c7bb3
+# %% ../../solutions/08_training/training.ipynb #2576658b
 # Solution
 
 def trainer_evaluate(self, dataloader):
@@ -474,7 +474,7 @@ def trainer_evaluate(self, dataloader):
 
 Trainer.evaluate = trainer_evaluate
 
-# %% ../../solutions/08_training/training.ipynb #6b327c88
+# %% ../../solutions/08_training/training.ipynb #036080df
 # Solution
 
 def trainer_save_checkpoint(self, path: str):
@@ -518,7 +518,7 @@ def trainer_save_checkpoint(self, path: str):
 
 Trainer.save_checkpoint = trainer_save_checkpoint
 
-# %% ../../solutions/08_training/training.ipynb #05c3253c
+# %% ../../solutions/08_training/training.ipynb #4bf271d4
 # Solution
 
 def trainer_load_checkpoint(self, path: str):

--- a/data/trentorch/core/transformers.py
+++ b/data/trentorch/core/transformers.py
@@ -18,11 +18,11 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'MB_TO_BYTES', 'TinyGPT', 'create_causal_mask', 'LayerNorm', 'MLP', 'TransformerBlock',
            'GPT']
 
-# %% ../../solutions/13_transformers/transformers.ipynb #16a3b520
+# %% ../../solutions/13_transformers/transformers.ipynb #11395085
 #| default_exp core.transformers
 #| export
 
-# %% ../../solutions/13_transformers/transformers.ipynb #1bc9c612
+# %% ../../solutions/13_transformers/transformers.ipynb #036992e7
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -72,7 +72,7 @@ def create_causal_mask(seq_len: int) -> Tensor:
     mask = np.tril(np.ones((seq_len, seq_len), dtype=np.float32))
     return Tensor(mask[np.newaxis, :, :])  # Add batch dimension
 
-# %% ../../solutions/13_transformers/transformers.ipynb #87f43326
+# %% ../../solutions/13_transformers/transformers.ipynb #6cf92179
 # Solution
 
 
@@ -217,7 +217,7 @@ class LayerNorm:
         """Return learnable parameters."""
         return [self.gamma, self.beta]
 
-# %% ../../solutions/13_transformers/transformers.ipynb #8d29a28f
+# %% ../../solutions/13_transformers/transformers.ipynb #865fcd74
 # Solution
 
 class MLP:
@@ -300,7 +300,7 @@ class MLP:
         params.extend(self.linear2.parameters())
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #fbb4d8ee
+# %% ../../solutions/13_transformers/transformers.ipynb #63635070
 # Solution
 
 class TransformerBlock:
@@ -409,7 +409,7 @@ class TransformerBlock:
         params.extend(self.mlp.parameters())
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #be89f349
+# %% ../../solutions/13_transformers/transformers.ipynb #f8dd3d61
 # Solution
 
 class GPT:
@@ -614,6 +614,6 @@ class GPT:
 
         return params
 
-# %% ../../solutions/13_transformers/transformers.ipynb #a8a9ed09
+# %% ../../solutions/13_transformers/transformers.ipynb #e3dacb4d
 # Alias for backward compatibility with tests
 TinyGPT = GPT

--- a/data/trentorch/olympics.py
+++ b/data/trentorch/olympics.py
@@ -17,11 +17,11 @@
 # %% auto #0
 __all__ = ['rng', 'SimpleMLP', 'BenchmarkReport', 'generate_submission', 'save_submission']
 
-# %% ../solutions/20_capstone/capstone.ipynb #bb0b9be2
+# %% ../solutions/20_capstone/capstone.ipynb #ae757914
 #| default_exp olympics
 #| export
 
-# %% ../solutions/20_capstone/capstone.ipynb #aabf16a5
+# %% ../solutions/20_capstone/capstone.ipynb #662c331a
 import numpy as np
 rng = np.random.default_rng(7)
 import time
@@ -31,7 +31,7 @@ from typing import Dict, List, Tuple, Optional, Any
 import platform
 import sys
 
-# %% ../solutions/20_capstone/capstone.ipynb #01eb846c
+# %% ../solutions/20_capstone/capstone.ipynb #ccede895
 # Solution
 
 class SimpleMLP:
@@ -118,7 +118,7 @@ class SimpleMLP:
 if __name__ == "__main__":
     print("✅ SimpleMLP model defined")
 
-# %% ../solutions/20_capstone/capstone.ipynb #bdd77565
+# %% ../solutions/20_capstone/capstone.ipynb #84d5e7fb
 # Solution
 
 class BenchmarkReport:
@@ -262,7 +262,7 @@ class BenchmarkReport:
 if __name__ == "__main__":
     print("✅ BenchmarkReport class defined")
 
-# %% ../solutions/20_capstone/capstone.ipynb #239a69ff
+# %% ../solutions/20_capstone/capstone.ipynb #0c1b3361
 def generate_submission(
     baseline_report: BenchmarkReport,
     optimized_report: Optional[BenchmarkReport] = None,

--- a/data/trentorch/perf/acceleration.py
+++ b/data/trentorch/perf/acceleration.py
@@ -18,11 +18,11 @@
 __all__ = ['rng', 'DEFAULT_WARMUP_ITERATIONS', 'DEFAULT_TIMING_ITERATIONS', 'BYTES_PER_FLOAT32', 'vectorized_matmul',
            'fused_gelu', 'tiled_matmul']
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #6bfba28d
+# %% ../../solutions/17_acceleration/acceleration.ipynb #77defefa
 #| default_exp perf.acceleration
 #| export
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #dbdaf9a0
+# %% ../../solutions/17_acceleration/acceleration.ipynb #66c62ce7
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -35,11 +35,11 @@ DEFAULT_WARMUP_ITERATIONS = 2  # Default warmup iterations for timing
 DEFAULT_TIMING_ITERATIONS = 5  # Default timing iterations for measurement
 BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #717b2641
+# %% ../../solutions/17_acceleration/acceleration.ipynb #e2bfb7f0
 # Import from TrenTorch package (previous modules must be completed and exported)
 from ..core.tensor import Tensor
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #9c3874c8
+# %% ../../solutions/17_acceleration/acceleration.ipynb #1b850c06
 # Solution
 
 def vectorized_matmul(a: Tensor, b: Tensor) -> Tensor:
@@ -112,7 +112,7 @@ def vectorized_matmul(a: Tensor, b: Tensor) -> Tensor:
     return Tensor(result_data)
     ### END SOLUTION
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #8a5cabff
+# %% ../../solutions/17_acceleration/acceleration.ipynb #5f2144a9
 # Solution
 
 def fused_gelu(x: Tensor) -> Tensor:
@@ -175,7 +175,7 @@ def fused_gelu(x: Tensor) -> Tensor:
     return Tensor(result_data)
     ### END SOLUTION
 
-# %% ../../solutions/17_acceleration/acceleration.ipynb #78cfff1b
+# %% ../../solutions/17_acceleration/acceleration.ipynb #4c66b7c9
 # Solution
 
 def tiled_matmul(a: Tensor, b: Tensor, tile_size: int = 64) -> Tensor:

--- a/data/trentorch/perf/benchmarking.py
+++ b/data/trentorch/perf/benchmarking.py
@@ -21,12 +21,12 @@ __all__ = ['DEFAULT_WARMUP_RUNS', 'DEFAULT_MEASUREMENT_RUNS', 'rng', 'BenchmarkR
            'benchsuite_plot_pareto_frontier', 'benchsuite_generate_report', 'MLPerf', 'mlperf_run_standard_benchmark',
            'mlperf_run_all_benchmarks', 'mlperf_generate_compliance_report', 'analyze_optimization_techniques']
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9b711724
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #7c0582fd
 # Constants for benchmarking defaults
 DEFAULT_WARMUP_RUNS = 5  # Default warmup runs for JIT compilation and cache warming
 DEFAULT_MEASUREMENT_RUNS = 10  # Default measurement runs for statistical significance
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d9739b0a
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #93298ca2
 import numpy as np
 rng = np.random.default_rng(7)
 import time
@@ -89,7 +89,7 @@ except ImportError:
 # Import Profiler from Module 14 for measurement reuse
 from .profiling import Profiler
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #7b7b5442
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #b3c861f9
 # Solution
 
 @dataclass
@@ -166,7 +166,7 @@ class BenchmarkResult:
         return f"{self.metric_name}: {self.mean:.4f} ± {self.std:.4f} (n={self.count})"
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #23ef19be
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ef9b99a8
 # Solution
 
 @contextmanager
@@ -211,7 +211,7 @@ def precise_timer():
         timer.elapsed = time.perf_counter() - timer.start_time
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #c090fa04
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #522cc3df
 # Solution
 
 class Benchmark:
@@ -265,7 +265,7 @@ class Benchmark:
         # Process memory measurement uses tracemalloc (via Profiler)
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #42e1a920
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2d8385f6
 # Solution
 
     # --- Benchmark.run_latency_benchmark ---
@@ -325,7 +325,7 @@ def benchmark_run_latency_benchmark(self, input_shape: Tuple[int, ...] = (1, 28,
 
 Benchmark.run_latency_benchmark = benchmark_run_latency_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ce9975d3
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #174d027f
 # Solution
 
     # --- Benchmark.run_accuracy_benchmark ---
@@ -381,7 +381,7 @@ def benchmark_run_accuracy_benchmark(self) -> Dict[str, BenchmarkResult]:
 
 Benchmark.run_accuracy_benchmark = benchmark_run_accuracy_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #3f1774b3
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #a0e806e8
 # Solution
 
     # --- Benchmark.run_memory_benchmark ---
@@ -432,7 +432,7 @@ def benchmark_run_memory_benchmark(self, input_shape: Tuple[int, ...] = (1, 28, 
 
 Benchmark.run_memory_benchmark = benchmark_run_memory_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #fc26ca82
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #50621a90
 # Solution
 
     # --- Benchmark.compare_models ---
@@ -485,7 +485,7 @@ def benchmark_compare_models(self, metric: str = "latency"):
 
 Benchmark.compare_models = benchmark_compare_models
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2eaba677
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #8a93dc04
 # Solution
 
 class BenchmarkSuite:
@@ -528,7 +528,7 @@ class BenchmarkSuite:
         self.results = {}
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #a8b40866
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d534b112
 # Solution
 
     # --- BenchmarkSuite.run_full_benchmark ---
@@ -571,7 +571,7 @@ def benchsuite_run_full_benchmark(self) -> Dict[str, Dict[str, BenchmarkResult]]
 
 BenchmarkSuite.run_full_benchmark = benchsuite_run_full_benchmark
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f775628e
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f86ec76a
 # Solution
 
     # --- BenchmarkSuite._estimate_energy_efficiency ---
@@ -633,7 +633,7 @@ def _benchsuite_estimate_energy_efficiency(self) -> Dict[str, BenchmarkResult]:
 
 BenchmarkSuite._estimate_energy_efficiency = _benchsuite_estimate_energy_efficiency
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #60818475
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #886f71df
 # Solution
 
     # --- BenchmarkSuite.plot_results and plot_pareto_frontier ---
@@ -775,7 +775,7 @@ def benchsuite_plot_pareto_frontier(self, x_metric: str = 'latency', y_metric: s
 
 BenchmarkSuite.plot_pareto_frontier = benchsuite_plot_pareto_frontier
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #e099227b
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #df0166ab
 # Solution
 
 def _benchsuite_format_results_summary(self) -> List[str]:
@@ -823,7 +823,7 @@ def _benchsuite_format_results_summary(self) -> List[str]:
 
 BenchmarkSuite._format_results_summary = _benchsuite_format_results_summary
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9ae30924
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #71cf8d5d
 # Solution
 
 def _benchsuite_format_recommendations(self) -> List[str]:
@@ -897,7 +897,7 @@ def _benchsuite_format_recommendations(self) -> List[str]:
 
 BenchmarkSuite._format_recommendations = _benchsuite_format_recommendations
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #040b82ef
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f292a3a7
 # Solution
 
 def benchsuite_generate_report(self) -> str:
@@ -950,7 +950,7 @@ def benchsuite_generate_report(self) -> str:
 
 BenchmarkSuite.generate_report = benchsuite_generate_report
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #2a4f4398
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #172878a6
 # Solution
 
 class MLPerf:
@@ -1017,7 +1017,7 @@ class MLPerf:
         }
         ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #4e52e46d
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #6032a154
 # Solution
 
     # --- MLPerf._run_latency_test ---
@@ -1081,7 +1081,7 @@ def _mlperf_run_latency_test(self, model: Any, test_inputs: List[Any],
 
 MLPerf._run_latency_test = _mlperf_run_latency_test
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #d98f0c2a
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #764e35e8
 # Solution
 
 def _extract_pred_array(pred) -> np.ndarray:
@@ -1117,7 +1117,7 @@ def _extract_pred_array(pred) -> np.ndarray:
     return pred_array
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #101e63ee
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #b8167ce3
 # Solution
 
 def _mlperf_run_accuracy_test(self, model: Any, predictions: List[Any],
@@ -1174,7 +1174,7 @@ def _mlperf_run_accuracy_test(self, model: Any, predictions: List[Any],
 
 MLPerf._run_accuracy_test = _mlperf_run_accuracy_test
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #63803d26
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #a3682cba
 # Solution
 
     # --- MLPerf.run_standard_benchmark ---
@@ -1283,7 +1283,7 @@ def mlperf_run_all_benchmarks(self, model: Any) -> Dict[str, Dict[str, Any]]:
 
 MLPerf.run_all_benchmarks = mlperf_run_all_benchmarks
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ff0f2afe
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #6324e371
 # Solution
 
 def _mlperf_compile_report_data(self, results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
@@ -1357,7 +1357,7 @@ def _mlperf_compile_report_data(self, results: Dict[str, Dict[str, Any]]) -> Dic
 
 MLPerf._compile_report_data = _mlperf_compile_report_data
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #629a2261
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #0ed465ae
 # Solution
 
 def _mlperf_format_compliance_summary(self, report_data: Dict[str, Any]) -> str:
@@ -1410,7 +1410,7 @@ def _mlperf_format_compliance_summary(self, report_data: Dict[str, Any]) -> str:
 
 MLPerf._format_compliance_summary = _mlperf_format_compliance_summary
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #1f460de0
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #3d60a88a
 # Solution
 
 def mlperf_generate_compliance_report(self, results: Dict[str, Dict[str, Any]],
@@ -1449,7 +1449,7 @@ def mlperf_generate_compliance_report(self, results: Dict[str, Dict[str, Any]],
 
 MLPerf.generate_compliance_report = mlperf_generate_compliance_report
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #0bae017a
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #c6be2da5
 # Solution
 
 def _collect_base_metrics(base_name: str, benchmark_results: Dict) -> Dict[str, float]:
@@ -1476,7 +1476,7 @@ def _collect_base_metrics(base_name: str, benchmark_results: Dict) -> Dict[str, 
     return base_metrics
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #7f8e22e3
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #ca248b3e
 # Solution
 
 def _calculate_improvements(base_metrics: Dict[str, float], opt_metrics: Dict[str, float]) -> Dict[str, float]:
@@ -1514,7 +1514,7 @@ def _calculate_improvements(base_metrics: Dict[str, float], opt_metrics: Dict[st
     return improvements
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #9ac43e11
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #1153f78d
 # Solution
 
 def _generate_recommendations(all_improvements: Dict[str, Dict[str, float]]) -> Dict[str, Dict]:
@@ -1601,7 +1601,7 @@ def _generate_recommendations(all_improvements: Dict[str, Dict[str, float]]) -> 
     }
     ### END SOLUTION
 
-# %% ../../solutions/19_benchmarking/benchmarking.ipynb #f690f2d8
+# %% ../../solutions/19_benchmarking/benchmarking.ipynb #59198872
 # Solution
 
 def analyze_optimization_techniques(base_model: Any, optimized_models: List[Any],

--- a/data/trentorch/perf/compression.py
+++ b/data/trentorch/perf/compression.py
@@ -18,7 +18,7 @@
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'MB_TO_BYTES', 'measure_sparsity', 'magnitude_prune', 'structured_prune',
            'low_rank_approximate', 'KnowledgeDistillation', 'Compressor', 'verify_pruning_works']
 
-# %% ../../solutions/16_compression/compression.ipynb #3b568873
+# %% ../../solutions/16_compression/compression.ipynb #26d4e68a
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -37,7 +37,7 @@ MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
 # Sequential provides model container with .layers and .parameters()
 
-# %% ../../solutions/16_compression/compression.ipynb #6f141be5
+# %% ../../solutions/16_compression/compression.ipynb #16425fe6
 # Solution
 
 def measure_sparsity(model) -> float:
@@ -86,7 +86,7 @@ def measure_sparsity(model) -> float:
     return (zero_params / total_params) * 100.0
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #4c1b3481
+# %% ../../solutions/16_compression/compression.ipynb #f4887305
 # Solution
 
 def magnitude_prune(model, sparsity=0.9):
@@ -143,7 +143,7 @@ def magnitude_prune(model, sparsity=0.9):
     return model
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #92c2404f
+# %% ../../solutions/16_compression/compression.ipynb #2f873b47
 # Solution
 
 def structured_prune(model, prune_ratio=0.5):
@@ -202,7 +202,7 @@ def structured_prune(model, prune_ratio=0.5):
     return model
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #9d6673c3
+# %% ../../solutions/16_compression/compression.ipynb #fbfc0a87
 # Solution
 
 def low_rank_approximate(weight_matrix, rank_ratio=0.5):
@@ -246,7 +246,7 @@ def low_rank_approximate(weight_matrix, rank_ratio=0.5):
     return U_truncated, S_truncated, V_truncated
     ### END SOLUTION
 
-# %% ../../solutions/16_compression/compression.ipynb #02ea8a93
+# %% ../../solutions/16_compression/compression.ipynb #14255d42
 # Solution
 
 class KnowledgeDistillation:
@@ -365,7 +365,7 @@ class KnowledgeDistillation:
         else:
             return -np.mean(np.sum(labels * np.log(predictions + 1e-8), axis=1))
 
-# %% ../../solutions/16_compression/compression.ipynb #637d3419
+# %% ../../solutions/16_compression/compression.ipynb #a8101288
 class Compressor:
     """
     Complete compression system for milestone use.
@@ -433,7 +433,7 @@ class Compressor:
 # Note: measure_sparsity, magnitude_prune, structured_prune are defined earlier in this module.
 # The Compressor class above delegates to those functions, providing an OOP interface for milestones.
 
-# %% ../../solutions/16_compression/compression.ipynb #78bbea57
+# %% ../../solutions/16_compression/compression.ipynb #b058cddf
 def verify_pruning_works(model, target_sparsity=0.8):
     """
     Verify pruning actually creates zeros using real zero counting.

--- a/data/trentorch/perf/memoization.py
+++ b/data/trentorch/perf/memoization.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'KVCache', 'enable_kv_cache', 'disable_kv_cache']
 
-# %% ../../solutions/18_memoization/memoization.ipynb #d5919623
+# %% ../../solutions/18_memoization/memoization.ipynb #972c0ca8
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -31,7 +31,7 @@ from ..core.tensor import Tensor
 _BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 _MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/18_memoization/memoization.ipynb #88e6ddf9
+# %% ../../solutions/18_memoization/memoization.ipynb #5dc40b08
 # Solution
 
 class KVCache:
@@ -320,7 +320,7 @@ class KVCache:
             'total_elements': total_elements
         }
 
-# %% ../../solutions/18_memoization/memoization.ipynb #0bbc5abc
+# %% ../../solutions/18_memoization/memoization.ipynb #27fef6d0
 def _cached_generation_step(x, attention, cache_obj, layer_idx):
     """
     Execute a single cached generation step for one new token.
@@ -401,7 +401,7 @@ def _cached_generation_step(x, attention, cache_obj, layer_idx):
 
     return attention.out_proj.forward(concat_output)
 
-# %% ../../solutions/18_memoization/memoization.ipynb #8dc35ab6
+# %% ../../solutions/18_memoization/memoization.ipynb #2b788f1e
 # Solution
 
 def _create_cache_storage(model):
@@ -468,7 +468,7 @@ def _create_cache_storage(model):
     return cache, head_dim
     ### END SOLUTION
 
-# %% ../../solutions/18_memoization/memoization.ipynb #45575072
+# %% ../../solutions/18_memoization/memoization.ipynb #e9c4f440
 # Solution
 
 def _cached_attention_forward(block, x, cache_obj, layer_idx, original_forward):
@@ -525,7 +525,7 @@ def _cached_attention_forward(block, x, cache_obj, layer_idx, original_forward):
     return _cached_generation_step(x, block.attention, cache_obj, layer_idx)
     ### END SOLUTION
 
-# %% ../../solutions/18_memoization/memoization.ipynb #18601da2
+# %% ../../solutions/18_memoization/memoization.ipynb #e5fc54a3
 # Solution
 
 def enable_kv_cache(model):

--- a/data/trentorch/perf/profiling.py
+++ b/data/trentorch/perf/profiling.py
@@ -17,7 +17,7 @@
 # %% auto #0
 __all__ = ['rng', 'BYTES_PER_FLOAT32', 'KB_TO_BYTES', 'MB_TO_BYTES', 'Profiler', 'quick_profile', 'analyze_weight_distribution']
 
-# %% ../../solutions/14_profiling/profiling.ipynb #c3b13111
+# %% ../../solutions/14_profiling/profiling.ipynb #1b1f20ac
 import sys
 import os
 import time
@@ -38,7 +38,7 @@ BYTES_PER_FLOAT32 = 4  # Standard float32 size in bytes
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
 MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 
-# %% ../../solutions/14_profiling/profiling.ipynb #0b8f2f14
+# %% ../../solutions/14_profiling/profiling.ipynb #40c0b4b3
 # Solution
 
 class Profiler:
@@ -658,7 +658,7 @@ class Profiler:
         }
         ### END SOLUTION
 
-# %% ../../solutions/14_profiling/profiling.ipynb #92a774d7
+# %% ../../solutions/14_profiling/profiling.ipynb #922a4847
 def quick_profile(model, input_tensor, profiler=None):
     """
     Quick profiling function for immediate insights.
@@ -696,7 +696,7 @@ def quick_profile(model, input_tensor, profiler=None):
 
     return profile
 
-# %% ../../solutions/14_profiling/profiling.ipynb #3d93c931
+# %% ../../solutions/14_profiling/profiling.ipynb #b8fb92b6
 def analyze_weight_distribution(model, percentiles=[10, 25, 50, 75, 90]):
     """
     Analyze weight distribution across layers.

--- a/data/trentorch/perf/quantization.py
+++ b/data/trentorch/perf/quantization.py
@@ -19,7 +19,7 @@ __all__ = ['rng', 'INT8_MIN_VALUE', 'INT8_MAX_VALUE', 'INT8_RANGE', 'EPSILON', '
            'MB_TO_BYTES', 'quantize_int8', 'dequantize_int8', 'QuantizedLinear', 'quantize_model', 'Quantizer',
            'verify_quantization_works']
 
-# %% ../../solutions/15_quantization/quantization.ipynb #d3337ada
+# %% ../../solutions/15_quantization/quantization.ipynb #61adedea
 import os
 import numpy as np
 rng = np.random.default_rng(7)
@@ -46,7 +46,7 @@ MB_TO_BYTES = 1024 * 1024  # Megabytes to bytes conversion
 if __name__ == "__main__":
     print("Quantization module imports complete")
 
-# %% ../../solutions/15_quantization/quantization.ipynb #5f70e998
+# %% ../../solutions/15_quantization/quantization.ipynb #d826c439
 # Solution
 
 def quantize_int8(tensor: Tensor) -> Tuple[Tensor, float, int]:
@@ -126,7 +126,7 @@ def quantize_int8(tensor: Tensor) -> Tuple[Tensor, float, int]:
     return Tensor(quantized_data), scale, zero_point
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #ead013f4
+# %% ../../solutions/15_quantization/quantization.ipynb #10e9b26c
 # Solution
 
 def dequantize_int8(q_tensor: Tensor, scale: float, zero_point: int) -> Tensor:
@@ -165,7 +165,7 @@ def dequantize_int8(q_tensor: Tensor, scale: float, zero_point: int) -> Tensor:
     return Tensor(dequantized_data)
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #5a705919
+# %% ../../solutions/15_quantization/quantization.ipynb #0c9146a0
 # Solution
 
 class QuantizedLinear:
@@ -343,7 +343,7 @@ class QuantizedLinear:
         }
         ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #54652ceb
+# %% ../../solutions/15_quantization/quantization.ipynb #f449da53
 # Solution
 
 def _collect_layer_inputs(model, layer_index: int, calibration_data: List[Tensor], max_samples: int = 10) -> List[Tensor]:
@@ -386,7 +386,7 @@ def _collect_layer_inputs(model, layer_index: int, calibration_data: List[Tensor
     return sample_inputs
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #38c8a7d3
+# %% ../../solutions/15_quantization/quantization.ipynb #a82b6097
 # Solution
 
 def _quantize_single_layer(layer: Linear, calibration_inputs: Optional[List[Tensor]] = None) -> QuantizedLinear:
@@ -426,7 +426,7 @@ def _quantize_single_layer(layer: Linear, calibration_inputs: Optional[List[Tens
     return quantized_layer
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #1ff8ecf4
+# %% ../../solutions/15_quantization/quantization.ipynb #0000140d
 # Solution
 
 def quantize_model(model, calibration_data: Optional[List[Tensor]] = None) -> None:
@@ -489,7 +489,7 @@ def quantize_model(model, calibration_data: Optional[List[Tensor]] = None) -> No
         )
     ### END SOLUTION
 
-# %% ../../solutions/15_quantization/quantization.ipynb #c234fd88
+# %% ../../solutions/15_quantization/quantization.ipynb #b8d768f1
 class Quantizer:
     """
     Complete quantization system for milestone use.
@@ -571,7 +571,7 @@ class Quantizer:
 # Note: quantize_int8, dequantize_int8, and quantize_model are defined earlier in this module.
 # The Quantizer class above delegates to those functions, providing an OOP interface for milestones.
 
-# %% ../../solutions/15_quantization/quantization.ipynb #d31266c6
+# %% ../../solutions/15_quantization/quantization.ipynb #bc995a21
 def verify_quantization_works(original_model, quantized_model):
     """
     Verify quantization actually reduces memory using real .nbytes measurements.

--- a/platforms/cli/tests/test_release_regressions.py
+++ b/platforms/cli/tests/test_release_regressions.py
@@ -125,6 +125,58 @@ def test_scalar_left_tensor_ops_preserve_autograd():
     np.testing.assert_allclose(x.grad, [-3.0, -0.75])
 
 
+def test_mean_preserves_autograd():
+    """Regression test for #53: Tensor.mean() used to run the plain
+    module-01 implementation with no gradient tracking at all, while
+    Tensor.sum() (built from the same autograd.py) correctly did. mean()
+    is now built from the already-tracked sum() and division, so it
+    must propagate requires_grad and produce the analytically correct
+    gradient (d/dx mean(x) = 1/n for every axis shape)."""
+    from trentorch import Tensor
+
+    x = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+
+    result = x.mean()
+    assert result.requires_grad is True
+
+    result.backward()
+    np.testing.assert_allclose(x.grad, np.full((2, 3), 1.0 / 6.0))
+
+    x.zero_grad()
+    (x * x).mean(axis=0).sum().backward()
+    np.testing.assert_allclose(x.grad, 2 * x.data / 2)
+
+    x.zero_grad()
+    (x * x).mean(axis=1, keepdims=True).sum().backward()
+    np.testing.assert_allclose(x.grad, 2 * x.data / 3)
+
+
+def test_max_preserves_autograd():
+    """Regression test: Tensor.max() had the same gap mean() did before
+    #53 -- autograd.py patched sum/mean but never wired an autograd-aware
+    max, so it silently ran module 01's plain np.max wrapper with no
+    requires_grad propagation. Gradient should route only to the
+    argmax element(s), 1/(number of ties) each, zero everywhere else."""
+    from trentorch import Tensor
+
+    x = Tensor([[1.0, 5.0, 3.0], [4.0, 2.0, 6.0]], requires_grad=True)
+
+    result = x.max()
+    assert result.requires_grad is True
+
+    result.backward()
+    np.testing.assert_allclose(x.grad, [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+    x.zero_grad()
+    x.max(axis=1).sum().backward()
+    np.testing.assert_allclose(x.grad, [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    # Ties split the gradient equally between the tied elements.
+    x2 = Tensor([1.0, 3.0, 3.0], requires_grad=True)
+    x2.max().backward()
+    np.testing.assert_allclose(x2.grad, [0.0, 0.5, 0.5])
+
+
 def test_mlperf_optimization_loads_packaged_tinydigits():
     script = TRENTORCH_ROOT / "data" / "milestones" / "06_2018_mlperf" / "01_optimization_olympics.py"
     module = _import_script(script)


### PR DESCRIPTION
## Bug

Same class of bug as #53 (`mean()`): `autograd.py` wires `Tensor.sum = sum_op` and `Tensor.mean = mean_op`, but never an autograd-aware `Tensor.max`. `max()` was still running module 01's plain implementation, `np.max(...)` wrapped in a fresh `Tensor(result)`, no `requires_grad` propagation at all.

Found by checking every other reduction `Tensor` exposes for the same gap once `mean()`'s was fixed in #53.

Reproduced directly:
```python
t = Tensor([[1.,2.,3.],[4.,5.,6.]], requires_grad=True)
m = t.max()
m.requires_grad  # False
m.backward()
t.grad  # None
```
`sum()` on the identical input correctly propagates. Grepped the whole exported package: nothing internal calls `Tensor.max()` (numerical-stability code in softmax/losses all calls `np.max` on raw `.data` instead), so no internal code path is affected today, but any student who reaches for `.max()` directly (e.g. building their own max-pool or a custom loss) would get silently zero gradients with no error.

## Fix

Unlike `mean()`, `max()` isn't a smooth combination of already-tracked ops, so it gets its own `MaxBackward` `Function` (same structural pattern as the existing `SumBackward`): gradient routes only to the argmax element(s), split equally among ties, zero everywhere else. Wired as `Tensor.max = max_op` alongside the existing `sum`/`mean` lines.

## Verification

- Reproduced the bug, confirmed the fix against exact expected values (no axis, per-axis, and a tie case splitting the gradient 0.5/0.5).
- 30-trial finite-difference check against random inputs, both no-axis and per-axis reductions: 0/30 failures at `5e-3` tolerance.
- Full local suite: 899 passed / 2 failed, both pre-existing and unrelated (documented in `docs/testing-strategy.md`).
- `ruff check .` and `ruff format --check .` both clean.
- Regression tests added in `platforms/cli/tests/test_release_regressions.py` for both this fix and #53's mean() fix, which shipped without one.