### PR TITLE
Add MC/DC coverage for the CLI's real risk-bearing decisions

### DIFF
--- a/data/milestones/tests/test_milestones_run.py
+++ b/data/milestones/tests/test_milestones_run.py
@@ -52,7 +52,7 @@ def run_milestone(milestone_id: str, part: int = None, timeout: int = 300) -> tu
         cmd.extend(["--part", str(part)])
 
     env = os.environ.copy()
-    env["TREN_ALLOW_SYSTEM"] = "1"  # Allow running without venv
+    env["TITO_ALLOW_SYSTEM"] = "1"  # Allow running without venv
     env["PYTHONPATH"] = str(TRENTORCH_ROOT)
 
     # Auto-answer prompts by providing 'n' to stdin (decline syncing achievements, etc.)

--- a/platforms/cli/tests/test_dev_test_build_gate.py
+++ b/platforms/cli/tests/test_dev_test_build_gate.py
@@ -1,0 +1,99 @@
+"""
+MC/DC coverage for DevTestCommand.run()'s Step-1 build gate.
+
+`tren dev test` decides whether to (re)build the package before running
+anything with:
+
+    if not args.no_build and not run_user_journey and not run_inline:
+
+a 3-condition AND (call the conditions P = not args.no_build,
+Q = not run_user_journey, R = not run_inline). This is the exact gate
+docs/testing-strategy.md's pre-merge checklist item 1 depends on ("re-run
+tren dev export --all... before trusting a local pytest run"): if this
+condition is ever miswired, a maintainer could silently run tests against
+a stale package and get a false "zero regressions" signal, which is what
+actually produced two of the incidents in section 6 of that doc. It had
+no dedicated test before this.
+
+A 4-case MC/DC set for a 3-term AND: an all-true baseline, plus each
+condition flipped alone.
+"""
+
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from platforms.cli.cli_platform.dev.test import DevTestCommand, TestResult
+from platforms.cli.core.config import CLIConfig
+
+PROJECT_ROOT_MARKER = __file__
+
+
+def _base_args(**overrides):
+    defaults = {
+        "no_build": False,
+        "inline": False,
+        "all": False,
+        "unit": False,
+        "integration": False,
+        "e2e": False,
+        "cli": False,
+        "milestone": False,
+        "module": None,
+        "ci": True,
+        "verbose": False,
+        "parallel": False,
+        "user_journey": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+@pytest.fixture
+def command(tmp_path):
+    cmd = DevTestCommand(CLIConfig.from_project_root(tmp_path))
+    # Force the build step to be attempted (rather than skipped via the
+    # "package already built" import check) and every phase -- build
+    # included -- to report failure immediately, so run() always exits
+    # after the first phase it actually reaches. That isolates the Step 1
+    # gate itself: whichever branch it takes, nothing past the first
+    # phase call runs for real (no subprocess, no actual build/export).
+    cmd._check_imports = MagicMock(return_value=False)
+    failing = TestResult(name="phase", passed=False)
+    cmd._build_package = MagicMock(return_value=failing)
+    cmd._run_inline_tests = MagicMock(return_value=failing)
+    cmd._run_unit_tests = MagicMock(return_value=failing)
+    cmd._run_cli_tests = MagicMock(return_value=failing)
+    cmd._run_integration_tests = MagicMock(return_value=failing)
+    cmd._run_e2e_tests = MagicMock(return_value=failing)
+    cmd._run_milestone_tests = MagicMock(return_value=failing)
+    cmd._run_user_journey = MagicMock(return_value=failing)
+    return cmd
+
+
+def test_build_runs_when_all_gate_conditions_true(command):
+    """P=True, Q=True, R=True -> build attempted (baseline)."""
+    command.run(_base_args())
+    assert command._build_package.called
+
+
+def test_no_build_flag_skips_build(command):
+    """P=False, Q=True, R=True -> build skipped. Paired with the baseline:
+    only P differs, isolating args.no_build's effect."""
+    command.run(_base_args(no_build=True))
+    assert not command._build_package.called
+
+
+def test_user_journey_skips_build(command):
+    """P=True, Q=False, R=True -> build skipped. Paired with the baseline:
+    only Q differs, isolating user_journey's effect."""
+    command.run(_base_args(user_journey=True))
+    assert not command._build_package.called
+
+
+def test_inline_skips_build(command):
+    """P=True, Q=True, R=False -> build skipped. Paired with the baseline:
+    only R differs, isolating args.inline's effect."""
+    command.run(_base_args(inline=True))
+    assert not command._build_package.called

--- a/platforms/cli/tests/test_main_venv_guard.py
+++ b/platforms/cli/tests/test_main_venv_guard.py
@@ -1,0 +1,151 @@
+"""
+MC/DC coverage for TrenTorchCLI.run()'s virtual-environment guard.
+
+Every `tren` command other than `setup` (and no-command) is gated by:
+
+    in_venv = sys.prefix != sys.base_prefix or os.environ.get("VIRTUAL_ENV") is not None
+    allow_system = os.environ.get("TITO_ALLOW_SYSTEM") == "1"
+    if not in_venv and not allow_system:
+        ... return 1
+
+three independent atomic conditions (call them A, B, C). This is the single
+highest-traffic decision in the whole CLI -- it runs on every invocation of
+every command -- and had no dedicated test before this.
+
+While writing this, found a real (if currently harmless) instance of the
+project's own documented rename-migration bug pattern (section 6 of
+docs/testing-strategy.md, the `tito` -> `trentorch` renames): three test
+files (platforms/cli/tests/test_release_regressions.py,
+tests/e2e/test_user_journey.py, data/milestones/tests/test_milestones_run.py)
+set `TREN_ALLOW_SYSTEM=1` in the subprocess env expecting it to be this
+escape hatch, but this code (and every doc describing it, and both CI
+workflow files) has only ever read `TITO_ALLOW_SYSTEM`. It doesn't fail any
+test today only because those subprocess calls already run with
+sys.executable pointing at an activated venv, so A is independently True
+and C's value never gets exercised. Fixed those three call sites to set the
+name this guard actually reads.
+
+Four cases give real MC/DC: a "blocked" baseline (A=F, B=F, C=F) plus each
+condition flipped alone (each flip alone must move the outcome to
+"allowed").
+"""
+
+import sys
+
+import pytest
+
+from platforms.cli.cli_platform.setup import SetupCommand
+from platforms.cli.main import TrenTorchCLI
+from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+
+class _SpyModuleCommand(ModuleWorkflowCommand):
+    """create_parser() instantiates every registered command class up
+    front to read its .description and call .add_arguments() while
+    building the full argparse parser, for every command, not just the
+    one being invoked -- so a bare stand-in without that real interface
+    breaks parser construction entirely. Subclassing the real command and
+    overriding only run() keeps that interface while still avoiding any
+    real dispatch side effect once the guard lets execution through."""
+
+    def run(self, parsed_args):
+        return 0
+
+
+@pytest.fixture
+def cli(monkeypatch):
+    app = TrenTorchCLI()
+    monkeypatch.setitem(app.commands, "module", _SpyModuleCommand)
+    return app
+
+
+def _set_conditions(monkeypatch, *, differing_prefix, virtual_env_set, allow_system_set):
+    if differing_prefix:
+        monkeypatch.setattr(sys, "prefix", "/fake/venv")
+        monkeypatch.setattr(sys, "base_prefix", "/fake/system")
+    else:
+        monkeypatch.setattr(sys, "prefix", "/fake/same")
+        monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+
+    if virtual_env_set:
+        monkeypatch.setenv("VIRTUAL_ENV", "/fake/venv")
+    else:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    if allow_system_set:
+        monkeypatch.setenv("TITO_ALLOW_SYSTEM", "1")
+    else:
+        monkeypatch.delenv("TITO_ALLOW_SYSTEM", raising=False)
+
+
+def test_no_venv_signal_and_no_override_is_blocked(cli, monkeypatch, capsys):
+    """A=False, B=False, C=False -> blocked (the baseline every flip below
+    is paired against)."""
+    _set_conditions(monkeypatch, differing_prefix=False, virtual_env_set=False, allow_system_set=False)
+
+    result = cli.run(["module"])
+
+    assert result == 1
+    assert "Virtual Environment Required" in capsys.readouterr().out
+
+
+def test_differing_prefix_alone_is_allowed(cli, monkeypatch):
+    """A=True, B=False, C=False -> allowed. Paired with the baseline: only
+    A differs, isolating sys.prefix != sys.base_prefix's effect."""
+    _set_conditions(monkeypatch, differing_prefix=True, virtual_env_set=False, allow_system_set=False)
+
+    assert cli.run(["module"]) == 0
+
+
+def test_virtual_env_var_alone_is_allowed(cli, monkeypatch):
+    """A=False, B=True, C=False -> allowed. Paired with the baseline: only
+    B differs, isolating the VIRTUAL_ENV env var's effect."""
+    _set_conditions(monkeypatch, differing_prefix=False, virtual_env_set=True, allow_system_set=False)
+
+    assert cli.run(["module"]) == 0
+
+
+def test_allow_system_alone_is_allowed(cli, monkeypatch):
+    """A=False, B=False, C=True -> allowed. Paired with the baseline: only
+    C differs, isolating TITO_ALLOW_SYSTEM's effect."""
+    _set_conditions(monkeypatch, differing_prefix=False, virtual_env_set=False, allow_system_set=True)
+
+    assert cli.run(["module"]) == 0
+
+
+def test_setup_command_bypasses_the_guard_entirely(monkeypatch):
+    """The guard only applies to `parsed_args.command not in ["setup",
+    None]` -- confirms `tren setup` itself is exempt regardless of venv
+    state, since it's the command that's supposed to create the venv."""
+    app = TrenTorchCLI()
+    ran = {}
+
+    class _RecordingSetup(SetupCommand):
+        def run(self, parsed_args):
+            ran["called"] = True
+            return 0
+
+    monkeypatch.setitem(app.commands, "setup", _RecordingSetup)
+    monkeypatch.setattr(sys, "prefix", "/fake/same")
+    monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("TITO_ALLOW_SYSTEM", raising=False)
+
+    assert app.run(["setup"]) == 0
+    assert ran.get("called") is True
+
+
+def test_os_environ_get_matches_the_name_used_everywhere_else():
+    """Documents the migration-name gap directly: os.environ has no
+    built-in tie to what a test file happens to set, so this pins the
+    literal env var name main.py reads, the same way section 6 of
+    docs/testing-strategy.md pins check_tinytorch_package()'s `import
+    tito` regression -- a future rename of this variable should have to
+    touch this assertion on purpose."""
+    import inspect
+
+    from platforms.cli import main as main_module
+
+    source = inspect.getsource(main_module.TrenTorchCLI.run)
+    assert 'os.environ.get("TITO_ALLOW_SYSTEM")' in source
+    assert "TREN_ALLOW_SYSTEM" not in source

--- a/platforms/cli/tests/test_release_regressions.py
+++ b/platforms/cli/tests/test_release_regressions.py
@@ -201,7 +201,7 @@ def test_generation_speedup_import_error_lists_actual_requirements():
 
 def test_milestone_list_uses_actual_history_start_year():
     env = os.environ.copy()
-    env["TREN_ALLOW_SYSTEM"] = "1"
+    env["TITO_ALLOW_SYSTEM"] = "1"
     result = subprocess.run(
         [sys.executable, "-m", "platforms.cli.main", "milestone", "list", "--simple"],
         cwd=TRENTORCH_ROOT,

--- a/platforms/cli/tests/test_status_analyzer_environment.py
+++ b/platforms/cli/tests/test_status_analyzer_environment.py
@@ -1,0 +1,85 @@
+"""
+MC/DC coverage for TinyTorchStatusAnalyzer.check_environment()'s venv-detection
+decision.
+
+The decision is `hasattr(sys, "real_prefix") or (hasattr(sys, "base_prefix")
+and sys.base_prefix != sys.prefix)`, three independent conditions (call them
+A, B, C). It has no dedicated unit test today: the only thing that touches
+it is tests/environment/test_setup_validation.py, which re-derives the same
+boolean expression against the *real* running interpreter rather than
+exercising the analyzer's own code with each condition varied, so it can't
+catch a typo like `and` swapped for `or`, or `!=` swapped for `==`, in this
+function.
+
+This gets real MC/DC coverage: four cases, each fully pinning A, B, and C
+via monkeypatch (never relying on whatever venv state pytest happens to be
+running under), chosen so each condition's independent effect on the
+decision outcome is demonstrated by a pair of cases that differ only in
+that one condition, with the others held fixed at values that don't mask
+it.
+"""
+
+import sys
+
+from platforms.cli.core.status_analyzer import TinyTorchStatusAnalyzer
+
+
+def _virtual_env_active(monkeypatch, tmp_path, *, real_prefix, base_prefix, prefix):
+    if real_prefix is None:
+        monkeypatch.delattr(sys, "real_prefix", raising=False)
+    else:
+        monkeypatch.setattr(sys, "real_prefix", real_prefix, raising=False)
+
+    if base_prefix is None:
+        monkeypatch.delattr(sys, "base_prefix", raising=False)
+    else:
+        monkeypatch.setattr(sys, "base_prefix", base_prefix, raising=False)
+
+    monkeypatch.setattr(sys, "prefix", prefix)
+
+    return TinyTorchStatusAnalyzer(repo_path=tmp_path).check_environment()["virtual_env_active"]
+
+
+def test_real_prefix_alone_drives_true(monkeypatch, tmp_path):
+    """A=True, B=False (C short-circuited) -> True."""
+    result = _virtual_env_active(
+        monkeypatch, tmp_path, real_prefix="/fake/system-python", base_prefix=None, prefix="/fake/venv"
+    )
+    assert result is True
+
+
+def test_no_real_prefix_no_base_prefix_is_false(monkeypatch, tmp_path):
+    """A=False, B=False -> False. Paired with the test above: only A
+    differs (True -> False), isolating A's effect."""
+    result = _virtual_env_active(
+        monkeypatch, tmp_path, real_prefix=None, base_prefix=None, prefix="/fake/venv"
+    )
+    assert result is False
+
+
+def test_base_prefix_true_with_differing_paths_is_true(monkeypatch, tmp_path):
+    """A=False, B=True, C=True -> True. Paired with the next test: only B
+    differs (True vs False below), C held at True (paths differ)."""
+    result = _virtual_env_active(
+        monkeypatch, tmp_path, real_prefix=None, base_prefix="/fake/base", prefix="/fake/venv"
+    )
+    assert result is True
+
+
+def test_no_base_prefix_attr_is_false(monkeypatch, tmp_path):
+    """A=False, B=False -> False. Paired with the previous test: only B
+    differs (True -> False), isolating B's effect."""
+    result = _virtual_env_active(
+        monkeypatch, tmp_path, real_prefix=None, base_prefix=None, prefix="/fake/venv"
+    )
+    assert result is False
+
+
+def test_base_prefix_equal_to_prefix_is_false(monkeypatch, tmp_path):
+    """A=False, B=True, C=False -> False. Paired with
+    test_base_prefix_true_with_differing_paths_is_true: only C differs
+    (True -> False), isolating C's effect."""
+    result = _virtual_env_active(
+        monkeypatch, tmp_path, real_prefix=None, base_prefix="/fake/same-path", prefix="/fake/same-path"
+    )
+    assert result is False

--- a/platforms/cli/tests/test_test_runner_pytest_parsing.py
+++ b/platforms/cli/tests/test_test_runner_pytest_parsing.py
@@ -1,0 +1,69 @@
+"""
+MC/DC coverage for _parse_pytest_output()'s per-line decision.
+
+The decision that gates whether a line of captured pytest -v output is
+treated as a test result at all is:
+
+    "::" in line and ("PASSED" in line or "FAILED" in line)
+
+three independent conditions (call them X, Y, Z). This decides what a
+student is actually told passed or failed after `tren module test`, and
+had no dedicated test at all before this: the only coverage was indirect,
+through fixtures that happen to produce output matching the common case.
+
+Four cases give real MC/DC: each condition's independent effect on the
+decision is shown by a pair of cases differing only in that condition.
+"""
+
+from platforms.cli.processes.module_workflow.test_runner import _parse_pytest_output
+
+
+def test_double_colon_and_passed_is_counted():
+    """X=True, Y=True, Z=False -> counted, passed=True."""
+    stdout = "tests/01_tensor/test_shapes.py::TestTensor::test_reshape PASSED"
+    result = _parse_pytest_output(stdout, "")
+
+    assert len(result) == 1
+    assert result[0]["passed"] is True
+
+
+def test_no_double_colon_is_not_counted():
+    """X=False, Y=True, Z=False -> not counted. Paired with the test above:
+    only X differs, isolating X's effect."""
+    stdout = "some unrelated log line mentioning PASSED but no path separator"
+    result = _parse_pytest_output(stdout, "")
+
+    assert result == []
+
+
+def test_double_colon_without_status_word_is_not_counted():
+    """X=True, Y=False, Z=False -> not counted. Paired with the first test:
+    only Y differs (True -> False), X held True, isolating Y's effect."""
+    stdout = "tests/01_tensor/test_shapes.py::TestTensor::test_reshape COLLECTED"
+    result = _parse_pytest_output(stdout, "")
+
+    assert result == []
+
+
+def test_double_colon_and_failed_is_counted():
+    """X=True, Y=False, Z=True -> counted, passed=False. Paired with the
+    previous test: only Z differs (False -> True), isolating Z's effect."""
+    stdout = "tests/01_tensor/test_shapes.py::TestTensor::test_reshape FAILED"
+    result = _parse_pytest_output(stdout, "")
+
+    assert len(result) == 1
+    assert result[0]["passed"] is False
+
+
+def test_duplicate_test_paths_are_deduplicated():
+    """Not part of the MC/DC set above, but a real behavior of the same
+    function worth locking down while adding its first test: a repeated
+    test_path (pytest sometimes echoes a line twice, e.g. with -rA summary
+    output) should only be counted once."""
+    stdout = (
+        "tests/01_tensor/test_shapes.py::TestTensor::test_reshape PASSED\n"
+        "tests/01_tensor/test_shapes.py::TestTensor::test_reshape PASSED\n"
+    )
+    result = _parse_pytest_output(stdout, "")
+
+    assert len(result) == 1

--- a/tests/e2e/test_user_journey.py
+++ b/tests/e2e/test_user_journey.py
@@ -34,7 +34,7 @@ def run_tren(args: list, cwd: Path | None = None, timeout: int = 60) -> tuple[in
 
     cmd = [sys.executable, "-m", "platforms.cli.main"] + args
     env = os.environ.copy()
-    env["TREN_ALLOW_SYSTEM"] = "1"  # Allow running outside venv for tests
+    env["TITO_ALLOW_SYSTEM"] = "1"  # Allow running outside venv for tests
     result = subprocess.run(
         cmd,
         cwd=cwd or PROJECT_ROOT,


### PR DESCRIPTION
## Scope

Full-project MC/DC (Modified Condition/Decision Coverage) isn't the right fit for this repo, and `docs/testing-strategy.md` section 7 says so on purpose: most branches in `data/src/` exist to teach one concept once, not to be hardened against adversarial input, so exhaustively testing every independent condition there would pad a coverage number without catching real bugs.

Where MC/DC-style testing does pay off is `platforms/cli/` (13K lines of real, non-pedagogical control flow: argument parsing, the export pipeline, workflow state machines) and a couple of already-flagged risk spots. So this PR is scoped there: found every genuinely compound (3+ atomic condition) boolean decision in `platforms/cli/`, and added real MC/DC coverage for the four with actual behavioral stakes. All four had zero dedicated tests before this.

## What got covered

1. **`main.py`'s virtual-env guard** — the single highest-traffic decision in the whole CLI, runs on every `tren` invocation.
2. **`status_analyzer.py`'s venv-detection decision** — gates the "Activate virtual environment" action item in `tren system health`.
3. **`test_runner.py`'s pytest-output-line decision** — decides what a student is told passed or failed after `tren module test`.
4. **`dev/test.py`'s build-gate decision** — the exact mechanism `docs/testing-strategy.md`'s pre-merge checklist item 1 depends on; get it wrong and a maintainer silently tests a stale package, which is what produced two real incidents in section 6 of that doc.

Each new test file's docstring states the exact MC/DC case set (which pair of test cases isolates which condition) rather than just asserting outcomes.

## A real bug found along the way

Writing #1's tests turned up a live instance of this project's own documented rename-migration bug pattern (testing-strategy.md section 6, the `tito` → `trentorch` renames): three test files set `TREN_ALLOW_SYSTEM=1` in a subprocess env expecting it to be the guard's escape hatch, but the guard itself (and every doc describing it, and both CI workflow files) has only ever read `TITO_ALLOW_SYSTEM`. It never failed anything because those subprocess calls already run inside an activated venv independently, so the escape hatch's value was never actually exercised. Fixed the three call sites to the name the code actually reads.

## Verification

- Every one of the four decisions was mutation-tested by hand (`and`→`or`, `!=`→`==`) to confirm the new tests actually fail on the mutation, not just pass on the unmodified code — proof this catches real logic errors, not coverage theater. (Mutations applied, tests re-run to confirm the expected failures, then reverted — none of that is in the diff.)
- Full local suite: 919 passed / 2 failed, same two pre-existing failures documented in `docs/testing-strategy.md`, up from the 897/2 baseline (+20 new tests here, +2 already on `main` from #58).
- `ruff check .` and `ruff format --check .` both clean.

## Deliberately out of scope

`preflight.py`'s failure-detail-display decision and two CLI-arg-parsing decisions flagged in the same sweep (`main.py`'s `-h`/`--help` shortcut and banner-skip logic): pure console-formatting, not a correctness or behavior-gating decision, lower stakes than the four above for the time spent.
