### PR TITLE
Finish the MC/DC pass: every remaining decision from PR #60's list, two more real bugs

### DIFF
--- a/platforms/cli/cli_platform/dev/preflight.py
+++ b/platforms/cli/cli_platform/dev/preflight.py
@@ -352,7 +352,13 @@ class PreflightCommand(BaseCommand):
         # Check module count
         start = time.time()
         modules_dir = project_root / "data" / "modules"
-        if modules_dir.exists():
+        # is_dir(), not just exists(): the required-dirs loop above already
+        # reports data/modules/ missing-or-not-a-directory as its own FAIL,
+        # but iterdir() on a path that exists as a plain file raises
+        # NotADirectoryError -- this used to crash the whole preflight run
+        # instead of just skipping the module-count check, in exactly the
+        # state the earlier check already flagged as broken.
+        if modules_dir.is_dir():
             module_count = len([d for d in modules_dir.iterdir() if d.is_dir() and d.name[0].isdigit()])
             if module_count >= 15:
                 category.checks.append(

--- a/platforms/cli/processes/milestone/command.py
+++ b/platforms/cli/processes/milestone/command.py
@@ -456,7 +456,15 @@ class MilestoneCommand(BaseCommand):
 
             if missing_modules:
                 part_info = ""
-                if args.part is not None and len(script_configs) == 1:
+                # `and len(script_configs) == 1` used to also gate this: every
+                # code path above that leaves script_configs longer than one
+                # element (the "run every part" fallback a few dozen lines up)
+                # only runs when args.part is None, so by the time args.part
+                # is not None here, script_configs is already guaranteed to
+                # have exactly one element -- the length check could never
+                # independently be False, dead weight rather than a real
+                # second condition.
+                if args.part is not None:
                     part_info = f" (Part {args.part})"
                 console.print(
                     Panel(

--- a/platforms/cli/tests/test_console_logo_coloring.py
+++ b/platforms/cli/tests/test_console_logo_coloring.py
@@ -1,0 +1,67 @@
+"""
+MC/DC-adjacent coverage for print_ascii_logo's per-line coloring decision
+(i == 0 / i >= 1 and i <= 5 / else). The 7-line ASCII logo is a fixed,
+hardcoded constant inside the function rather than a parameter, so the
+loop bounds can never see a genuinely different input in production --
+independently varying "i >= 1" from "i <= 5" the way other decisions in
+this pass do isn't meaningful here. What's real and worth locking down
+instead: that the actual, fixed 7-line asset gets exactly the coloring
+the code intends, checked directly against Rich's own style spans rather
+than guessing from rendered ANSI text.
+"""
+
+from rich.align import Align
+
+from platforms.cli.core.console import print_ascii_logo
+from platforms.cli.core.theme import Theme
+
+
+def _captured_logo_text(monkeypatch):
+    captured = {}
+
+    def fake_center(renderable, *a, **k):
+        captured["text"] = renderable
+        return renderable
+
+    monkeypatch.setattr(Align, "center", staticmethod(fake_center))
+    print_ascii_logo()
+    return captured["text"]
+
+
+def test_first_line_is_pure_flame_color(monkeypatch):
+    """i == 0 -> the whole line gets FLAME_COLOR, no per-character
+    splitting."""
+    text = _captured_logo_text(monkeypatch)
+    first_line = text.plain.split("\n")[0]
+    style_at_start = next(s.style for s in text.spans if s.start == 0)
+    assert style_at_start == Theme.BRAND_FLAME
+    # A single span covering the whole first line confirms it wasn't
+    # split character-by-character the way lines 1-5 are.
+    assert any(s.start == 0 and s.end == len(first_line) for s in text.spans)
+
+
+def test_middle_lines_are_split_per_character_for_tiny_letters(monkeypatch):
+    """1 <= i <= 5 -> each character is styled individually (TINY_COLOR
+    for T/I/N/Y, TORCH_COLOR otherwise), not one span per line."""
+    text = _captured_logo_text(monkeypatch)
+    lines = text.plain.split("\n")
+    line_1_start = len(lines[0]) + 1  # +1 for the newline
+    # A per-character split means many short spans in this region, not
+    # one long one covering the whole line.
+    spans_in_line_1 = [s for s in text.spans if line_1_start <= s.start < line_1_start + len(lines[1])]
+    assert len(spans_in_line_1) > 1
+
+
+def test_last_logo_line_is_pure_torch_color_not_split(monkeypatch):
+    """i == 6 (the else branch, past the i <= 5 boundary) -> the whole
+    line gets TORCH_COLOR as one span again, like line 0 but a different
+    color."""
+    text = _captured_logo_text(monkeypatch)
+    lines = text.plain.split("\n")
+    last_logo_line = lines[6]
+    last_line_start = sum(len(line_text) + 1 for line_text in lines[:6])
+    matching_spans = [
+        s for s in text.spans if s.start == last_line_start and s.end == last_line_start + len(last_logo_line)
+    ]
+    assert len(matching_spans) == 1
+    assert matching_spans[0].style == Theme.BRAND_PRIMARY

--- a/platforms/cli/tests/test_health_venv_and_kernel_checks.py
+++ b/platforms/cli/tests/test_health_venv_and_kernel_checks.py
@@ -1,0 +1,146 @@
+"""
+MC/DC coverage for HealthCommand's venv-status decision (venv_exists and
+in_venv), the kernel-issue-recording decision, and _check_jupyter_kernel's
+own registered-kernel decision.
+"""
+
+import subprocess
+import sys
+from io import StringIO
+
+from rich.console import Console
+
+import platforms.cli.commands.base as base_module
+from platforms.cli.cli_platform.system.health import HealthCommand
+from platforms.cli.core.config import CLIConfig
+
+# ---------------------------------------------------------------------------
+# venv_exists and in_venv
+# ---------------------------------------------------------------------------
+
+
+def _run_health(tmp_path, monkeypatch, *, venv_exists, in_venv):
+    fake_venv = tmp_path / ".venv"
+    if venv_exists:
+        fake_venv.mkdir()
+    monkeypatch.setattr(base_module, "get_venv_path", lambda: fake_venv)
+
+    if in_venv:
+        monkeypatch.setenv("VIRTUAL_ENV", str(fake_venv))
+    else:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(sys, "prefix", "/fake/same")
+        monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+        monkeypatch.delattr(sys, "real_prefix", raising=False)
+
+    cmd = HealthCommand(CLIConfig.from_project_root(tmp_path))
+    monkeypatch.setattr(cmd, "_check_jupyter_kernel", lambda: ("[dim]○ Skipped[/dim]", "test"))
+    monkeypatch.setattr(cmd, "_get_kernel_python", lambda: None)
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=300, no_color=True)
+    cmd.run(None)
+    return buf.getvalue()
+
+
+def test_venv_exists_and_active_shows_ok(tmp_path, monkeypatch):
+    """Baseline: venv_exists True, in_venv True -> OK."""
+    out = _run_health(tmp_path, monkeypatch, venv_exists=True, in_venv=True)
+    assert "Virtual Environment" in out and "OK" in out
+
+
+def test_venv_exists_but_not_active_shows_not_activated(tmp_path, monkeypatch):
+    """venv_exists True, in_venv False -> "Not Activated", not OK.
+    Paired with the baseline: only in_venv differs, isolating that half
+    of the and."""
+    out = _run_health(tmp_path, monkeypatch, venv_exists=True, in_venv=False)
+    # The fixed-width Status column can wrap "Not Activated" onto two
+    # lines, so check both fragments rather than one exact substring.
+    assert "Not" in out and "Activated" in out
+    assert "exists but is not activated" in out
+
+
+def test_no_venv_directory_shows_missing_regardless_of_env_vars(tmp_path, monkeypatch):
+    """venv_exists False -> "Missing", regardless of in_venv (the elif
+    chain's final else). Paired with the baseline: only venv_exists
+    differs, isolating that half of the and."""
+    out = _run_health(tmp_path, monkeypatch, venv_exists=False, in_venv=True)
+    assert "Missing" in out
+
+
+# ---------------------------------------------------------------------------
+# "❌" in kernel_status or "⚠️" in kernel_status
+# ---------------------------------------------------------------------------
+
+
+def _run_health_with_kernel_status(tmp_path, monkeypatch, kernel_status):
+    monkeypatch.setattr(base_module, "get_venv_path", lambda: tmp_path / ".venv")
+    (tmp_path / ".venv").mkdir()
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+
+    cmd = HealthCommand(CLIConfig.from_project_root(tmp_path))
+    monkeypatch.setattr(cmd, "_check_jupyter_kernel", lambda: (kernel_status, "detail text"))
+    monkeypatch.setattr(cmd, "_get_kernel_python", lambda: None)
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=300, no_color=True)
+    cmd.run(None)
+    return buf.getvalue()
+
+
+def test_failed_kernel_status_is_recorded_as_an_issue(tmp_path, monkeypatch):
+    """Baseline: "❌" present -> recorded as an issue (shown in the
+    action-items summary)."""
+    out = _run_health_with_kernel_status(tmp_path, monkeypatch, "[red]❌ Not found[/red]")
+    assert "• detail text" in out
+
+
+def test_warning_kernel_status_is_recorded_as_an_issue(tmp_path, monkeypatch):
+    """Isolates the second half of the or: "⚠️" present, "❌" absent."""
+    out = _run_health_with_kernel_status(tmp_path, monkeypatch, "[yellow]⚠️  Mismatch[/yellow]")
+    assert "• detail text" in out
+
+
+def test_ok_kernel_status_is_not_recorded_as_an_issue(tmp_path, monkeypatch):
+    """Neither symbol present -> not recorded as an issue. Paired with
+    the tests above: only the symbol's presence differs, isolating that
+    condition."""
+    out = _run_health_with_kernel_status(tmp_path, monkeypatch, "[green]✅ Registered[/green]")
+    assert "• detail text" not in out
+
+
+# ---------------------------------------------------------------------------
+# _check_jupyter_kernel: result.returncode == 0 and "tinytorch" in result.stdout
+# ---------------------------------------------------------------------------
+
+
+def _check_jupyter_kernel(tmp_path, monkeypatch, *, returncode, stdout):
+    def fake_run(cmd_args, **kwargs):
+        return subprocess.CompletedProcess(cmd_args, returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    cmd = HealthCommand(CLIConfig.from_project_root(tmp_path))
+    return cmd._check_jupyter_kernel()
+
+
+def test_kernelspec_success_with_tinytorch_registered(tmp_path, monkeypatch):
+    """Baseline: returncode == 0 True, "tinytorch" in stdout True ->
+    registered."""
+    status, detail = _check_jupyter_kernel(tmp_path, monkeypatch, returncode=0, stdout="python3\ntinytorch\n")
+    assert "Registered" in status
+
+
+def test_kernelspec_success_without_tinytorch(tmp_path, monkeypatch):
+    """returncode == 0 True, "tinytorch" in stdout False -> the and is
+    False, falls to the "no tinytorch kernel" branch. Paired with the
+    baseline: only whether tinytorch is listed differs, isolating that
+    half of the and."""
+    status, detail = _check_jupyter_kernel(tmp_path, monkeypatch, returncode=0, stdout="python3\n")
+    assert "Registered" not in status
+    assert "install --user --name tinytorch" in detail
+
+
+def test_kernelspec_command_itself_fails(tmp_path, monkeypatch):
+    """returncode == 0 is False -> the and is False regardless of
+    stdout content. Paired with the baseline: only returncode differs,
+    isolating that half of the and."""
+    status, detail = _check_jupyter_kernel(tmp_path, monkeypatch, returncode=1, stdout="tinytorch\n")
+    assert "Registered" not in status

--- a/platforms/cli/tests/test_info_venv_status.py
+++ b/platforms/cli/tests/test_info_venv_status.py
@@ -1,0 +1,102 @@
+"""
+MC/DC coverage for info.py's own copy of the venv-detection decision
+(_gather_system_info's in_venv) and InfoCommand.run's venv_exists and
+in_venv display decision. Same shape already proven in
+test_status_analyzer_environment.py and test_main_venv_guard.py; kept
+concise here since it's a genuine, separate copy of the same logic in a
+different file, not because the pattern itself needs re-litigating.
+"""
+
+import os
+import sys
+from io import StringIO
+
+from rich.console import Console
+
+from platforms.cli.cli_platform.system.info import InfoCommand, _gather_system_info
+from platforms.cli.core.config import CLIConfig
+
+# ---------------------------------------------------------------------------
+# in_venv = VIRTUAL_ENV is not None or (base_prefix != prefix) or real_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_virtual_env_var_alone_reports_active(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path))
+    monkeypatch.setattr(sys, "prefix", "/same")
+    monkeypatch.setattr(sys, "base_prefix", "/same")
+    monkeypatch.delattr(sys, "real_prefix", raising=False)
+    info = _gather_system_info(tmp_path)
+    assert info["venv_active"] is True
+
+
+def test_differing_prefixes_alone_reports_active(monkeypatch, tmp_path):
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", "/venv")
+    monkeypatch.setattr(sys, "base_prefix", "/system")
+    monkeypatch.delattr(sys, "real_prefix", raising=False)
+    info = _gather_system_info(tmp_path)
+    assert info["venv_active"] is True
+
+
+def test_none_of_the_three_signals_reports_inactive(monkeypatch, tmp_path):
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", "/same")
+    monkeypatch.setattr(sys, "base_prefix", "/same")
+    monkeypatch.delattr(sys, "real_prefix", raising=False)
+    info = _gather_system_info(tmp_path)
+    assert info["venv_active"] is False
+
+
+# ---------------------------------------------------------------------------
+# InfoCommand.run: venv_exists and in_venv
+# ---------------------------------------------------------------------------
+
+
+def _run_info(tmp_path, monkeypatch, *, venv_exists, in_venv):
+    fake_venv = tmp_path / ".venv"
+    if venv_exists:
+        fake_venv.mkdir()
+
+    import platforms.cli.commands.base as base_module
+
+    monkeypatch.setattr(base_module, "get_venv_path", lambda: fake_venv)
+    monkeypatch.setattr(
+        "platforms.cli.cli_platform.system.info._gather_system_info",
+        lambda venv_path: {
+            "python_version": "3.x",
+            "platform": "test",
+            "tinytorch_version": "test",
+            "numpy_version": "test",
+            "venv_active": in_venv,
+        },
+    )
+
+    cmd = InfoCommand(CLIConfig.from_project_root(tmp_path))
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=200, no_color=True)
+    monkeypatch.setattr(
+        os, "environ", {**os.environ, "VIRTUAL_ENV": str(fake_venv)} if in_venv else os.environ
+    )
+    cmd.run(type("Args", (), {"json": False})())
+    return buf.getvalue()
+
+
+def test_venv_exists_and_active_shows_ok_status(tmp_path, monkeypatch):
+    """Baseline: venv_exists True, in_venv True -> OK."""
+    out = _run_info(tmp_path, monkeypatch, venv_exists=True, in_venv=True)
+    assert "OK" in out
+
+
+def test_venv_exists_but_not_active_shows_not_activated(tmp_path, monkeypatch):
+    """venv_exists True, in_venv False -> Not Activated. Paired with the
+    baseline: only in_venv differs, isolating that half of the and."""
+    out = _run_info(tmp_path, monkeypatch, venv_exists=True, in_venv=False)
+    assert "Not Activated" in out
+
+
+def test_no_venv_directory_shows_not_found(tmp_path, monkeypatch):
+    """venv_exists False -> Not Found regardless of in_venv. Paired with
+    the baseline: only venv_exists differs, isolating that half."""
+    out = _run_info(tmp_path, monkeypatch, venv_exists=False, in_venv=True)
+    assert "Not Found" in out

--- a/platforms/cli/tests/test_jupyter_magic_exit_shutdown.py
+++ b/platforms/cli/tests/test_jupyter_magic_exit_shutdown.py
@@ -1,0 +1,83 @@
+"""
+MC/DC coverage for TrenMagics.exit's kernel-vs-process shutdown decision:
+self.shell is not None and hasattr(self.shell, "kernel").
+
+Extreme care here: the False branch of this decision calls os._exit(0),
+a real, immediate process termination with no exception raised and no
+chance for pytest to report anything -- getting the mock wrong would
+silently kill the whole test run. os._exit is mocked before anything
+else in every test in this file, and every other side-effecting call
+(display, network, sleep) is mocked too so this magic method can be
+exercised as a pure decision instead of the real notebook-teardown
+sequence it drives in production.
+"""
+
+import os
+import time
+import urllib.request
+
+import platforms.cli.jupyter_magic as jupyter_magic_module
+from platforms.cli.jupyter_magic import TrenMagics
+
+
+class _FakeKernel:
+    def __init__(self):
+        self.shutdown_called = False
+
+    def do_shutdown(self, restart):
+        self.shutdown_called = True
+
+
+class _ShellWithKernel:
+    def __init__(self):
+        self.kernel = _FakeKernel()
+
+
+class _ShellWithoutKernel:
+    pass
+
+
+def _exit_magic(monkeypatch, shell):
+    # os._exit first, before anything else can go wrong.
+    exit_calls = []
+    monkeypatch.setattr(os, "_exit", lambda code: exit_calls.append(code))
+
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(jupyter_magic_module, "display", lambda *a, **k: None)
+    monkeypatch.setattr(jupyter_magic_module, "_running_server", lambda: (None, None))
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: None)
+
+    magic = TrenMagics(shell=shell)
+    magic.exit("")
+    return exit_calls
+
+
+def test_shell_present_with_kernel_shuts_down_the_kernel_not_the_process(monkeypatch):
+    """Baseline: shell is not None True, hasattr(shell, "kernel") True
+    -> do_shutdown() called, os._exit never reached."""
+    shell = _ShellWithKernel()
+    exit_calls = _exit_magic(monkeypatch, shell)
+
+    assert shell.kernel.shutdown_called is True
+    assert exit_calls == []
+
+
+def test_shell_present_without_kernel_falls_back_to_process_exit(monkeypatch):
+    """shell is not None True, hasattr(shell, "kernel") False -> the and
+    is False, falls to os._exit(0). Paired with the baseline: only the
+    kernel attribute's presence differs, isolating that half of the and."""
+    shell = _ShellWithoutKernel()
+    exit_calls = _exit_magic(monkeypatch, shell)
+
+    assert exit_calls == [0]
+
+
+def test_no_shell_at_all_falls_back_to_process_exit(monkeypatch):
+    """shell is not None is False -> the and is False regardless of any
+    kernel attribute, short-circuits straight to os._exit(0). Paired
+    with the baseline: only whether a shell exists differs, isolating
+    that half of the and from the kernel-attribute check's independent
+    effect."""
+    exit_calls = _exit_magic(monkeypatch, shell=None)
+
+    assert exit_calls == [0]

--- a/platforms/cli/tests/test_milestone_list_run_now_text.py
+++ b/platforms/cli/tests/test_milestone_list_run_now_text.py
@@ -1,0 +1,70 @@
+"""
+MC/DC coverage for milestone/display.py's show_list "Run now" decision:
+prereqs_met and not is_complete.
+"""
+
+import json
+from io import StringIO
+
+from rich.console import Console
+
+import platforms.cli.processes.milestone.display as display_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.milestone.display import show_list
+
+
+def _milestone():
+    return {
+        "id": "1",
+        "name": "Test",
+        "emoji": "🎯",
+        "title": "Test",
+        "description": "Test",
+        "historical_context": "None",
+        "year": 1958,
+        "required_modules": [1],
+    }
+
+
+def _show_list(tmp_path, monkeypatch, *, completed_modules, completed_milestones):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "user_data").mkdir(exist_ok=True)
+    (tmp_path / "user_data" / "progress.json").write_text(
+        json.dumps({"completed_modules": completed_modules}), encoding="utf-8"
+    )
+    (tmp_path / "user_data" / "milestones.json").write_text(
+        json.dumps({"completed_milestones": completed_milestones}), encoding="utf-8"
+    )
+    monkeypatch.setattr(display_module, "MILESTONE_SCRIPTS", {"1": _milestone()})
+
+    from argparse import Namespace
+
+    config = CLIConfig.from_project_root(tmp_path)
+    buf = StringIO()
+    console = Console(file=buf, width=120, no_color=True)
+    show_list(config, console, Namespace(simple=False))
+    return buf.getvalue()
+
+
+def test_prereqs_met_and_not_complete_shows_run_now(tmp_path, monkeypatch):
+    """Baseline: prereqs_met True, is_complete False -> "Run now" shown."""
+    out = _show_list(tmp_path, monkeypatch, completed_modules=["01"], completed_milestones=[])
+    assert "Run now" in out
+
+
+def test_prereqs_met_but_already_complete_omits_run_now(tmp_path, monkeypatch):
+    """prereqs_met True, is_complete True -> "not is_complete" False,
+    the and is False -> no "Run now" text. Paired with the baseline:
+    only is_complete differs, isolating that half of the and."""
+    out = _show_list(tmp_path, monkeypatch, completed_modules=["01"], completed_milestones=["1"])
+    assert "Run now" not in out
+
+
+def test_prereqs_not_met_omits_run_now_and_shows_requirement(tmp_path, monkeypatch):
+    """prereqs_met False -> the and is False regardless of is_complete
+    (short-circuits). Paired with the baseline: only prereqs_met
+    differs, isolating that half of the and. Falls to the elif branch
+    instead, showing what's still required."""
+    out = _show_list(tmp_path, monkeypatch, completed_modules=[], completed_milestones=[])
+    assert "Run now" not in out
+    assert "Required: Complete modules" in out

--- a/platforms/cli/tests/test_milestone_run_command.py
+++ b/platforms/cli/tests/test_milestone_run_command.py
@@ -1,0 +1,315 @@
+"""
+MC/DC coverage for MilestoneCommand._handle_run_command's part-selection,
+default-part, missing-modules-part-text, and interactive-prompt decisions.
+"""
+
+import subprocess
+import sys
+from argparse import Namespace
+from io import StringIO
+
+from rich.console import Console
+
+import platforms.cli.processes.milestone.command as command_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.milestone.command import MilestoneCommand
+
+
+def _args(**overrides):
+    defaults = {"milestone_id": "01", "part": None, "skip_checks": True}
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+_BANNER_FIELDS = {
+    "emoji": "🚀",
+    "name": "Test Milestone",
+    "title": "A Test Milestone",
+    "historical_context": "None",
+    "description": "Test",
+    "year": 1958,
+}
+
+
+def _setup(tmp_path, monkeypatch, milestone_factory, *, run_returncode=0):
+    """milestone_factory(script_a_path, script_b_path) -> milestone dict
+    (banner-display fields merged in automatically)."""
+    script_a = str(tmp_path / "script_a.py")
+    script_b = str(tmp_path / "script_b.py")
+    (tmp_path / "script_a.py").write_text("", encoding="utf-8")
+    (tmp_path / "script_b.py").write_text("", encoding="utf-8")
+
+    milestone = {**_BANNER_FIELDS, **milestone_factory(script_a, script_b)}
+    monkeypatch.setattr(command_module, "MILESTONE_SCRIPTS", {"01": milestone})
+    monkeypatch.setattr(command_module, "MILESTONE_ALIASES", {})
+
+    captured = {"scripts": []}
+
+    def fake_run(cmd, **kwargs):
+        captured["scripts"].append(cmd[1])
+        return subprocess.CompletedProcess(cmd, returncode=run_returncode)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cmd = MilestoneCommand(CLIConfig.from_project_root(tmp_path))
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=120, no_color=True)
+    return cmd, buf, captured, script_a, script_b
+
+
+# ---------------------------------------------------------------------------
+# args.part < 1 or args.part > len(all_scripts)
+# ---------------------------------------------------------------------------
+
+
+def test_part_within_range_runs_that_script(tmp_path, monkeypatch):
+    """Baseline: part >= 1 and part <= len(scripts) -> neither half of
+    the or is True, valid part selected and run."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {"scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}]},
+    )
+
+    cmd._handle_run_command(_args(part=2))
+
+    assert captured["scripts"] == [script_b]
+    assert "Invalid part number" not in buf.getvalue()
+
+
+def test_part_zero_is_below_range(tmp_path, monkeypatch):
+    """part < 1 True -> the or is True, invalid-part error. Paired with
+    the baseline: only part's lower-bound violation differs, isolating
+    that half of the or."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path, monkeypatch, lambda a, b: {"scripts": [{"name": "A", "script": a}]}
+    )
+
+    result = cmd._handle_run_command(_args(part=0))
+
+    assert result == 1
+    assert "Invalid part number" in buf.getvalue()
+    assert captured["scripts"] == []
+
+
+def test_part_beyond_range_is_above_range(tmp_path, monkeypatch):
+    """part > len(scripts) True -> the or is True, invalid-part error.
+    Paired with the baseline: only part's upper-bound violation differs,
+    isolating that half of the or."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path, monkeypatch, lambda a, b: {"scripts": [{"name": "A", "script": a}]}
+    )
+
+    result = cmd._handle_run_command(_args(part=5))
+
+    assert result == 1
+    assert "Invalid part number" in buf.getvalue()
+    assert captured["scripts"] == []
+
+
+# ---------------------------------------------------------------------------
+# default_part is not None and 1 <= default_part <= len(all_scripts)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_default_part_is_used_when_no_part_flag_given(tmp_path, monkeypatch):
+    """Baseline: default_part not None True, in-range True -> that part
+    runs automatically."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {
+            "scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}],
+            "default_part": 2,
+        },
+    )
+
+    cmd._handle_run_command(_args(part=None))
+
+    assert captured["scripts"] == [script_b]
+
+
+def test_no_default_part_configured_runs_all_scripts(tmp_path, monkeypatch):
+    """default_part is not None is False (absent) -> short-circuits,
+    falls to running every script. Paired with the baseline: only the
+    presence of default_part differs, isolating that half of the and."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {"scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}]},
+    )
+
+    cmd._handle_run_command(_args(part=None))
+
+    assert captured["scripts"] == [script_a, script_b]
+
+
+def test_out_of_range_default_part_falls_back_to_all_scripts(tmp_path, monkeypatch):
+    """default_part not None True, but out of range (1 <= x <= len fails)
+    -> the and is False, falls to running every script. Paired with the
+    first baseline: only the range check differs, isolating that half of
+    the and from default_part's mere presence."""
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {
+            "scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}],
+            "default_part": 99,
+        },
+    )
+
+    cmd._handle_run_command(_args(part=None))
+
+    assert captured["scripts"] == [script_a, script_b]
+
+
+# ---------------------------------------------------------------------------
+# args.part is not None (previously "and len(script_configs) == 1", a
+# dead clause removed while writing this test -- see the fix's comment
+# in milestone/command.py)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_modules_with_a_specific_part_shows_part_in_error(tmp_path, monkeypatch):
+    """Baseline: args.part is not None -> the error message names the
+    specific part."""
+    from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+    monkeypatch.setattr(ModuleWorkflowCommand, "get_progress_data", lambda self: {"completed_modules": []})
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {
+            "scripts": [
+                {"name": "A", "script": a, "required_modules": [1]},
+                {"name": "B", "script": b, "required_modules": [2]},
+            ]
+        },
+    )
+
+    cmd._handle_run_command(_args(part=1, skip_checks=False))
+
+    assert "(Part 1)" in buf.getvalue()
+
+
+def test_missing_modules_without_a_part_flag_omits_part_text(tmp_path, monkeypatch):
+    """args.part is not None is False -> no part text shown even though
+    modules are missing. Paired with the baseline: only args.part's
+    presence differs, isolating this condition directly."""
+    from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+    monkeypatch.setattr(ModuleWorkflowCommand, "get_progress_data", lambda self: {"completed_modules": []})
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {
+            "scripts": [
+                {"name": "A", "script": a, "required_modules": [1]},
+                {"name": "B", "script": b, "required_modules": [2]},
+            ]
+        },
+    )
+
+    cmd._handle_run_command(_args(part=None, skip_checks=False))
+
+    assert "(Part" not in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# sys.stdin.isatty() and sys.stdout.isatty() -- the "press Enter to
+# begin" prompt shown once before running any script.
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_terminal_shows_the_press_enter_prompt(tmp_path, monkeypatch):
+    """Baseline: stdin.isatty() True, stdout.isatty() True -> the
+    console.input() prompt is called."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    cmd, buf, captured, script_a, script_b = _setup(tmp_path, monkeypatch, lambda a, b: {"script": a})
+    prompted = {}
+    monkeypatch.setattr(cmd.console, "input", lambda *a, **k: prompted.setdefault("called", True) or "")
+
+    cmd._handle_run_command(_args())
+
+    assert prompted.get("called") is True
+
+
+def test_non_interactive_stdin_skips_the_prompt(tmp_path, monkeypatch):
+    """stdin.isatty() False -> short-circuits, no prompt shown
+    regardless of stdout. Paired with the baseline: only stdin's tty
+    status differs, isolating that half of the and."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    cmd, buf, captured, script_a, script_b = _setup(tmp_path, monkeypatch, lambda a, b: {"script": a})
+    prompted = {}
+    monkeypatch.setattr(cmd.console, "input", lambda *a, **k: prompted.setdefault("called", True) or "")
+
+    cmd._handle_run_command(_args())
+
+    assert "called" not in prompted
+
+
+def test_non_interactive_stdout_skips_the_prompt(tmp_path, monkeypatch):
+    """stdout.isatty() False -> also skips, even with a real stdin tty.
+    Paired with the baseline: only stdout's tty status differs,
+    isolating that half of the and."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    cmd, buf, captured, script_a, script_b = _setup(tmp_path, monkeypatch, lambda a, b: {"script": a})
+    prompted = {}
+    monkeypatch.setattr(cmd.console, "input", lambda *a, **k: prompted.setdefault("called", True) or "")
+
+    cmd._handle_run_command(_args())
+
+    assert "called" not in prompted
+
+
+# ---------------------------------------------------------------------------
+# The second isatty gate: whether to ask "Continue to next part?" after a
+# part fails, only reachable with multiple parts and a non-zero exit.
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_terminal_asks_to_continue_after_a_failed_part(tmp_path, monkeypatch):
+    """Baseline: both isatty() True, a part fails, more than one part
+    configured -> the "Continue to next part?" prompt fires."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {"scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}]},
+        run_returncode=1,
+    )
+    monkeypatch.setattr(cmd.console, "input", lambda *a, **k: "")
+    asked = {}
+    monkeypatch.setattr("builtins.input", lambda *a, **k: asked.setdefault("called", True) or "y")
+
+    cmd._handle_run_command(_args())
+
+    assert asked.get("called") is True
+
+
+def test_non_interactive_after_a_failed_part_does_not_ask(tmp_path, monkeypatch):
+    """stdin.isatty() False -> the continue-prompt is skipped entirely;
+    non-interactive mode stops on the first failure instead (per the
+    code's own comment) rather than either asking or auto-continuing.
+    Paired with the baseline: only stdin's tty status differs, isolating
+    that half of this second and."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    cmd, buf, captured, script_a, script_b = _setup(
+        tmp_path,
+        monkeypatch,
+        lambda a, b: {"scripts": [{"name": "A", "script": a}, {"name": "B", "script": b}]},
+        run_returncode=1,
+    )
+    asked = {}
+    monkeypatch.setattr("builtins.input", lambda *a, **k: asked.setdefault("called", True) or "y")
+
+    cmd._handle_run_command(_args())
+
+    assert "called" not in asked
+    # Stopped after the first script's failure; the second never ran.
+    assert captured["scripts"] == [script_a]

--- a/platforms/cli/tests/test_milestone_system_status.py
+++ b/platforms/cli/tests/test_milestone_system_status.py
@@ -1,0 +1,136 @@
+"""
+MC/DC coverage for MilestoneSystem.get_milestone_status's can_unlock
+computation (a 3-atom and) and the "first eligible milestone becomes
+next_milestone" selection built on top of it.
+"""
+
+import json
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.milestone.system import MilestoneSystem
+
+
+def _system(tmp_path, monkeypatch, milestones, *, completed_modules=None, unlocked=None):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "user_data").mkdir(exist_ok=True)
+    (tmp_path / "user_data" / "progress.json").write_text(
+        json.dumps({"completed_modules": completed_modules or []}), encoding="utf-8"
+    )
+    if unlocked:
+        (tmp_path / "user_data" / "milestones.json").write_text(
+            json.dumps({"unlocked_milestones": unlocked, "completed_milestones": []}), encoding="utf-8"
+        )
+
+    system = MilestoneSystem(CLIConfig.from_project_root(tmp_path))
+    system.MILESTONES = milestones
+    return system
+
+
+def _milestone(required_modules=None, trigger_module=""):
+    return {
+        "name": "Test",
+        "title": "Test",
+        "required_modules": required_modules or [],
+        "trigger_module": trigger_module,
+    }
+
+
+# ---------------------------------------------------------------------------
+# can_unlock = required_complete and trigger_complete and not is_unlocked
+# ---------------------------------------------------------------------------
+
+
+def test_all_three_conditions_true_can_unlock(tmp_path, monkeypatch):
+    """Baseline: required_complete True, trigger_complete True,
+    is_unlocked False -> can_unlock True."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1], trigger_module="02")},
+        completed_modules=["01", "02"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is True
+
+
+def test_required_incomplete_blocks_unlock(tmp_path, monkeypatch):
+    """required_complete False -> can_unlock False. Paired with the
+    baseline: only required-module completion differs, isolating that
+    condition."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1], trigger_module="02")},
+        completed_modules=["02"],  # module 01 (required) not completed
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False
+
+
+def test_trigger_incomplete_blocks_unlock(tmp_path, monkeypatch):
+    """trigger_complete False -> can_unlock False. Paired with the
+    baseline: only the trigger module's completion differs, isolating
+    that condition."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1], trigger_module="02")},
+        completed_modules=["01"],  # trigger module 02 not completed
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False
+
+
+def test_already_unlocked_blocks_can_unlock(tmp_path, monkeypatch):
+    """is_unlocked True -> "not is_unlocked" False -> can_unlock False,
+    even though both other conditions are satisfied. Paired with the
+    baseline: only is_unlocked differs, isolating that condition."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1], trigger_module="02")},
+        completed_modules=["01", "02"],
+        unlocked=["1"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False
+
+
+# ---------------------------------------------------------------------------
+# elif milestone_status["can_unlock"] and not status["next_milestone"]
+# ---------------------------------------------------------------------------
+
+
+def test_first_eligible_milestone_becomes_next(tmp_path, monkeypatch):
+    """Two milestones both eligible to unlock -> only the first one
+    encountered (dict iteration order) becomes next_milestone; the
+    second's can_unlock True doesn't overwrite it, because
+    next_milestone is already set by then."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {
+            "1": _milestone(required_modules=[1]),
+            "2": _milestone(required_modules=[1]),
+        },
+        completed_modules=["01"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is True
+    assert status["milestones"]["2"]["can_unlock"] is True
+    assert status["next_milestone"] == "1"
+
+
+def test_no_eligible_milestone_leaves_next_milestone_none(tmp_path, monkeypatch):
+    """can_unlock False for every milestone -> next_milestone stays
+    None. Paired with the test above: only whether any milestone is
+    eligible differs, isolating can_unlock's effect on this selection."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1])},
+        completed_modules=[],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False
+    assert status["next_milestone"] is None

--- a/platforms/cli/tests/test_milestone_unlock_skip_check.py
+++ b/platforms/cli/tests/test_milestone_unlock_skip_check.py
@@ -1,0 +1,65 @@
+"""
+MC/DC coverage for check_and_run_milestone_unlocks's "already handled"
+skip check: milestone_id in unlocked or milestone_id in completed_milestones.
+"""
+
+import json
+from io import StringIO
+
+from rich.console import Console
+
+import platforms.cli.processes.milestone.system as system_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.milestone.command import MilestoneCommand
+from platforms.cli.processes.milestone.system import check_and_run_milestone_unlocks
+
+
+def _run(tmp_path, monkeypatch, *, unlocked, completed_milestones, module_completed):
+    (tmp_path / "user_data").mkdir(exist_ok=True)
+    (tmp_path / "user_data" / "progress.json").write_text(
+        json.dumps({"completed_modules": module_completed}), encoding="utf-8"
+    )
+    (tmp_path / "user_data" / "milestones.json").write_text(
+        json.dumps({"unlocked_milestones": unlocked, "completed_milestones": completed_milestones}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        system_module,
+        "MILESTONE_SCRIPTS",
+        {"1": {"name": "Test", "description": "Test", "required_modules": [1]}},
+    )
+    monkeypatch.setattr(MilestoneCommand, "_handle_run_command", lambda self, args: 0)
+
+    config = CLIConfig.from_project_root(tmp_path)
+    console = Console(file=StringIO(), width=120, no_color=True)
+    check_and_run_milestone_unlocks(config, console)
+
+    return json.loads((tmp_path / "user_data" / "milestones.json").read_text(encoding="utf-8"))
+
+
+def test_not_yet_unlocked_or_completed_and_requirements_met_gets_unlocked(tmp_path, monkeypatch):
+    """Baseline: neither half of the or is True -> the skip is not hit,
+    requirements are checked, and (met here) the milestone is newly
+    unlocked."""
+    result = _run(tmp_path, monkeypatch, unlocked=[], completed_milestones=[], module_completed=["01"])
+    assert "1" in result["unlocked_milestones"]
+
+
+def test_already_unlocked_is_skipped_without_reunlocking(tmp_path, monkeypatch):
+    """milestone_id in unlocked True -> skipped via continue, before
+    even checking requirements. Paired with the baseline: only whether
+    it's already unlocked differs, isolating that half of the or.
+    (unlock_dates should stay untouched -- nothing "newly" happened.)"""
+    result = _run(tmp_path, monkeypatch, unlocked=["1"], completed_milestones=[], module_completed=["01"])
+    assert result["unlocked_milestones"] == ["1"]
+    assert "unlock_dates" not in result or "1" not in result.get("unlock_dates", {})
+
+
+def test_already_completed_is_skipped_without_rerunning(tmp_path, monkeypatch):
+    """milestone_id in completed_milestones True -> also skipped.
+    Paired with the baseline: only whether it's already completed
+    differs, isolating that half of the or from "already unlocked"'s
+    independent effect."""
+    result = _run(tmp_path, monkeypatch, unlocked=[], completed_milestones=["1"], module_completed=["01"])
+    assert "1" not in result.get("unlocked_milestones", [])

--- a/platforms/cli/tests/test_preflight_failure_detail_display.py
+++ b/platforms/cli/tests/test_preflight_failure_detail_display.py
@@ -1,0 +1,93 @@
+"""
+MC/DC coverage for PreflightCommand._output_rich's failure-detail
+rendering: which failed checks get their stdout/stderr shown, and
+whether stdout is shown when stderr already covers it.
+"""
+
+from io import StringIO
+
+from rich.console import Console
+
+from platforms.cli.cli_platform.dev.preflight import CheckCategory, CheckResult, CheckStatus, PreflightCommand
+from platforms.cli.core.config import CLIConfig
+
+
+def _render(tmp_path, checks):
+    cmd = PreflightCommand(CLIConfig.from_project_root(tmp_path))
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=120, no_color=True)
+    category = CheckCategory(name="Test Category", emoji="🧪", checks=checks)
+    cmd._output_rich(
+        categories=[category],
+        all_passed=False,
+        duration=0.0,
+        total_passed=0,
+        total_failed=len(checks),
+        total_warned=0,
+        total_checks=len(checks),
+        level="full",
+        is_ci=False,
+        verbose=False,
+    )
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# check.status == CheckStatus.FAIL and (check.stdout or check.stderr)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_check_with_stdout_shows_failure_detail(tmp_path):
+    """Baseline: status FAIL True, stdout truthy -> detail block shown."""
+    out = _render(tmp_path, [CheckResult(name="thing", status=CheckStatus.FAIL, stdout="some output")])
+    assert "Failed: thing" in out
+
+
+def test_failed_check_with_neither_stream_shows_nothing_extra(tmp_path):
+    """status FAIL True, but stdout and stderr both empty -> "(stdout or
+    stderr)" is False, the and is False, no detail block. Paired with
+    the baseline: only the streams' emptiness differs, isolating that
+    half of the and."""
+    out = _render(tmp_path, [CheckResult(name="thing", status=CheckStatus.FAIL)])
+    assert "Failed: thing" not in out
+
+
+def test_passing_check_with_output_shows_nothing_extra(tmp_path):
+    """status FAIL is False -> the and is False regardless of stdout/
+    stderr content. Paired with the baseline: only status differs,
+    isolating that half of the and."""
+    out = _render(tmp_path, [CheckResult(name="thing", status=CheckStatus.PASS, stdout="some output")])
+    assert "Failed: thing" not in out
+
+
+# ---------------------------------------------------------------------------
+# check.stdout and not check.stderr
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_without_stderr_is_shown_as_output(tmp_path):
+    """Baseline: stdout truthy, stderr falsy -> stdout shown under
+    "Output (last lines)"."""
+    out = _render(
+        tmp_path, [CheckResult(name="thing", status=CheckStatus.FAIL, stdout="the real output here")]
+    )
+    assert "Output (last lines)" in out
+    assert "the real output here" in out
+
+
+def test_stdout_with_stderr_present_is_not_shown_as_output(tmp_path):
+    """stdout truthy, stderr also truthy -> "not stderr" is False, the
+    and is False -- stderr's own block is shown instead (already covers
+    the failure), stdout is skipped to avoid duplicating it. Paired with
+    the baseline: only stderr's presence differs, isolating that half of
+    the and."""
+    out = _render(
+        tmp_path,
+        [
+            CheckResult(
+                name="thing", status=CheckStatus.FAIL, stdout="stdout content", stderr="the real error"
+            )
+        ],
+    )
+    assert "Output (last lines)" not in out
+    assert "Error:" in out

--- a/platforms/cli/tests/test_preflight_module_tests_output.py
+++ b/platforms/cli/tests/test_preflight_module_tests_output.py
@@ -1,0 +1,40 @@
+"""
+MC/DC coverage for PreflightCommand._check_module_tests's failure-message
+extraction: "failed" in line.lower() or "error" in line.lower().
+"""
+
+from platforms.cli.cli_platform.dev.preflight import CheckStatus, PreflightCommand
+from platforms.cli.core.config import CLIConfig
+
+
+def _module_tests_check(tmp_path, monkeypatch, stdout):
+    (tmp_path / "tests" / "01_tensor").mkdir(parents=True)
+    cmd = PreflightCommand(CLIConfig.from_project_root(tmp_path))
+    monkeypatch.setattr(cmd, "_run_command", lambda *a, **k: (1, stdout, ""))
+    category = cmd._check_module_tests(tmp_path, quick=True, verbose=False)
+    return next(c for c in category.checks if c.name == "Module 01 tests")
+
+
+def test_failed_keyword_is_recognized(tmp_path, monkeypatch):
+    """Baseline: 'failed' present (case-insensitively) -> used as the
+    failure message."""
+    check = _module_tests_check(tmp_path, monkeypatch, "2 Failed, 3 passed\n")
+    assert check.status == CheckStatus.FAIL
+    assert "failed" in check.message.lower()
+
+
+def test_error_keyword_is_recognized(tmp_path, monkeypatch):
+    """Isolates the second half of the or: 'error' present, 'failed'
+    absent."""
+    check = _module_tests_check(tmp_path, monkeypatch, "CollectionERROR during import\n")
+    assert check.status == CheckStatus.FAIL
+    assert "error" in check.message.lower()
+
+
+def test_neither_keyword_falls_back_to_generic_message(tmp_path, monkeypatch):
+    """Neither keyword present -> falls back to the generic "Tests
+    failed" default. Paired with the tests above: only keyword presence
+    differs."""
+    check = _module_tests_check(tmp_path, monkeypatch, "something went sideways\n")
+    assert check.status == CheckStatus.FAIL
+    assert check.message == "Tests failed"

--- a/platforms/cli/tests/test_preflight_structure_check.py
+++ b/platforms/cli/tests/test_preflight_structure_check.py
@@ -1,0 +1,98 @@
+"""
+MC/DC coverage for PreflightCommand._check_structure's directory-existence
+decision (path.exists() and path.is_dir()), which appears twice
+(required and optional directories).
+"""
+
+from platforms.cli.cli_platform.dev.preflight import CheckStatus, PreflightCommand
+from platforms.cli.core.config import CLIConfig
+
+
+def _structure_check(tmp_path, *, data_modules_kind, trentorch_kind):
+    """kind: "dir", "file", or None (doesn't exist)."""
+    (tmp_path / "data" / "src").mkdir(parents=True)
+    (tmp_path / "data" / "milestones").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+    (tmp_path / "platforms" / "cli").mkdir(parents=True)
+
+    if data_modules_kind == "dir":
+        (tmp_path / "data" / "modules").mkdir(parents=True)
+    elif data_modules_kind == "file":
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "data" / "modules").write_text("", encoding="utf-8")
+
+    if trentorch_kind == "dir":
+        (tmp_path / "data" / "trentorch").mkdir(parents=True, exist_ok=True)
+    elif trentorch_kind == "file":
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "data" / "trentorch").write_text("", encoding="utf-8")
+
+    cmd = PreflightCommand(CLIConfig.from_project_root(tmp_path))
+    category = cmd._check_structure(tmp_path, verbose=False)
+    checks_by_name = {c.name: c for c in category.checks}
+    return checks_by_name
+
+
+# ---------------------------------------------------------------------------
+# Required dir loop: path.exists() and path.is_dir()
+# ---------------------------------------------------------------------------
+
+
+def test_existing_directory_passes(tmp_path):
+    """Baseline: exists() True, is_dir() True -> PASS."""
+    checks = _structure_check(tmp_path, data_modules_kind="dir", trentorch_kind=None)
+    assert checks["data/modules/ exists"].status == CheckStatus.PASS
+
+
+def test_missing_directory_fails(tmp_path):
+    """exists() False -> FAIL, is_dir() never matters. Paired with the
+    baseline: only existence differs, isolating that half of the and."""
+    checks = _structure_check(tmp_path, data_modules_kind=None, trentorch_kind=None)
+    assert checks["data/modules/ exists"].status == CheckStatus.FAIL
+
+
+def test_path_exists_as_a_file_not_a_directory_fails(tmp_path):
+    """exists() True, is_dir() False (it's a regular file at that path)
+    -> FAIL. Paired with the baseline: only is_dir()'s result differs,
+    isolating that half of the and."""
+    checks = _structure_check(tmp_path, data_modules_kind="file", trentorch_kind=None)
+    assert checks["data/modules/ exists"].status == CheckStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Optional dir loop: same decision, separate loop (data/trentorch/)
+# ---------------------------------------------------------------------------
+
+
+def test_optional_directory_present_passes(tmp_path):
+    """Same decision, the optional-directories loop: exists() True,
+    is_dir() True -> PASS."""
+    checks = _structure_check(tmp_path, data_modules_kind="dir", trentorch_kind="dir")
+    assert checks["data/trentorch/ exists"].status == CheckStatus.PASS
+
+
+def test_optional_directory_as_a_file_warns_not_fails(tmp_path):
+    """Same decision in the optional loop: exists() True, is_dir() False
+    -> WARN (not FAIL -- optional dirs use WARN on either "missing" or
+    "not a directory", the required-dirs loop's own separate FAIL
+    branch is a distinct copy of the same is_dir() decision, not this
+    one)."""
+    checks = _structure_check(tmp_path, data_modules_kind="dir", trentorch_kind="file")
+    assert checks["data/trentorch/ exists"].status == CheckStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# Regression: modules_dir.is_dir() before the module-count iterdir() call.
+# Used to be modules_dir.exists(), which raised NotADirectoryError and
+# crashed the whole preflight run if data/modules existed as a plain file.
+# ---------------------------------------------------------------------------
+
+
+def test_data_modules_as_a_file_does_not_crash_the_module_count_check(tmp_path):
+    """A state the required-dirs loop already flags as FAIL (data/modules
+    exists but isn't a directory) used to crash _check_structure entirely
+    a few lines later, instead of just skipping the module-count check
+    it can't meaningfully run in that state."""
+    checks = _structure_check(tmp_path, data_modules_kind="file", trentorch_kind=None)
+    assert checks["data/modules/ exists"].status == CheckStatus.FAIL
+    assert not any(name.startswith("Module count") for name in checks)

--- a/platforms/cli/tests/test_reset_deletion_targeting.py
+++ b/platforms/cli/tests/test_reset_deletion_targeting.py
@@ -1,0 +1,154 @@
+"""
+MC/DC coverage for the file/directory-targeting decisions in the two
+reset commands -- real, destructive deletion logic, so getting these
+wrong either deletes hand-written files or leaves generated ones behind.
+"""
+
+from argparse import Namespace
+
+from platforms.cli.cli_platform.package.reset import ResetCommand
+from platforms.cli.cli_platform.system.reset import SystemResetCommand
+from platforms.cli.core.config import CLIConfig
+
+# ---------------------------------------------------------------------------
+# package/reset.py _reset_package:
+#   str(rel_path).replace("\\", "/") not in NON_GENERATED
+#   and py_file.name != "__init__.py"
+# ---------------------------------------------------------------------------
+
+
+def _reset_package(tmp_path, monkeypatch, files: dict[str, str]):
+    monkeypatch.chdir(tmp_path)
+    pkg_dir = tmp_path / "data" / "trentorch"
+    for rel_path, content in files.items():
+        full = pkg_dir / rel_path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content, encoding="utf-8")
+
+    cmd = ResetCommand(CLIConfig.from_project_root(tmp_path))
+    cmd._reset_package(Namespace(force=True))
+    return {p.relative_to(pkg_dir).as_posix() for p in pkg_dir.rglob("*.py")}
+
+
+def test_a_generated_file_is_removed(tmp_path, monkeypatch):
+    """Baseline: not in NON_GENERATED True, not __init__.py True ->
+    removed."""
+    remaining = _reset_package(tmp_path, monkeypatch, {"core/tensor.py": "x"})
+    assert "core/tensor.py" not in remaining
+
+
+def test_a_non_generated_hand_written_file_is_preserved(tmp_path, monkeypatch):
+    """not in NON_GENERATED is False -> the and is False, preserved.
+    Paired with the baseline: only NON_GENERATED membership differs,
+    isolating that half of the and."""
+    remaining = _reset_package(tmp_path, monkeypatch, {"export_sanitizer.py": "x"})
+    assert "export_sanitizer.py" in remaining
+
+
+def test_any_init_file_is_preserved_regardless_of_directory(tmp_path, monkeypatch):
+    """py_file.name != "__init__.py" is False -> the and is False,
+    preserved, even for an __init__.py nested somewhere not literally
+    matching a NON_GENERATED entry. Paired with the baseline: only
+    whether the filename is __init__.py differs, isolating that half of
+    the and from NON_GENERATED-membership's independent effect."""
+    remaining = _reset_package(tmp_path, monkeypatch, {"core/__init__.py": "x"})
+    assert "core/__init__.py" in remaining
+
+
+def test_a_mix_removes_only_the_generated_file(tmp_path, monkeypatch):
+    """Sanity check combining all three cases in one reset."""
+    remaining = _reset_package(
+        tmp_path,
+        monkeypatch,
+        {
+            "core/tensor.py": "x",
+            "export_sanitizer.py": "x",
+            "core/__init__.py": "x",
+        },
+    )
+    assert remaining == {"export_sanitizer.py", "core/__init__.py"}
+
+
+# ---------------------------------------------------------------------------
+# system/reset.py run(): item.is_dir() and item.name[0].isdigit()
+# (module-directory clearing during `tren reset system`)
+# ---------------------------------------------------------------------------
+
+
+def _system_reset_modules(tmp_path, monkeypatch, entries: dict[str, str]):
+    """entries: name -> "dir" or "file"."""
+    modules_dir = tmp_path / "data" / "modules"
+    modules_dir.mkdir(parents=True)
+    for name, kind in entries.items():
+        if kind == "dir":
+            (modules_dir / name).mkdir()
+        else:
+            (modules_dir / name).write_text("", encoding="utf-8")
+
+    cmd = SystemResetCommand(CLIConfig.from_project_root(tmp_path))
+    cmd.run(Namespace(force=True, ci=True, backup=False, keep_progress=True))
+    return {p.name for p in modules_dir.iterdir()}
+
+
+def test_digit_prefixed_module_directory_is_cleared(tmp_path, monkeypatch):
+    """Baseline: is_dir() True, name[0].isdigit() True -> removed."""
+    remaining = _system_reset_modules(tmp_path, monkeypatch, {"01_tensor": "dir"})
+    assert "01_tensor" not in remaining
+
+
+def test_non_digit_prefixed_directory_is_preserved(tmp_path, monkeypatch):
+    """is_dir() True, name[0].isdigit() False -> preserved. Paired with
+    the baseline: only the name's first character differs, isolating
+    that half of the and."""
+    remaining = _system_reset_modules(tmp_path, monkeypatch, {"__pycache__": "dir"})
+    assert "__pycache__" in remaining
+
+
+def test_digit_prefixed_file_is_preserved(tmp_path, monkeypatch):
+    """is_dir() False (it's a file, not a directory), even though the
+    name starts with a digit -> preserved. Paired with the baseline:
+    only is_dir()'s result differs, isolating that half of the and."""
+    remaining = _system_reset_modules(tmp_path, monkeypatch, {"01_stray.txt": "file"})
+    assert "01_stray.txt" in remaining
+
+
+# ---------------------------------------------------------------------------
+# system/reset.py run(): not args.force and not args.ci
+# (the interactive "type 'yes' to confirm" prompt before a destructive
+# system reset)
+# ---------------------------------------------------------------------------
+
+
+def _system_reset_prompt(tmp_path, monkeypatch, *, force, ci, response):
+    modules_dir = tmp_path / "data" / "modules"
+    modules_dir.mkdir(parents=True)
+    (modules_dir / "01_tensor").mkdir()
+
+    monkeypatch.setattr("builtins.input", lambda *a, **k: response)
+    cmd = SystemResetCommand(CLIConfig.from_project_root(tmp_path))
+    cmd.run(Namespace(force=force, ci=ci, backup=False, keep_progress=True))
+    return {p.name for p in modules_dir.iterdir()}
+
+
+def test_neither_force_nor_ci_asks_and_respects_a_no(tmp_path, monkeypatch):
+    """Baseline: not force True, not ci True -> the and is True, prompt
+    shown; a non-"yes" answer cancels, nothing is deleted."""
+    remaining = _system_reset_prompt(tmp_path, monkeypatch, force=False, ci=False, response="n")
+    assert "01_tensor" in remaining
+
+
+def test_force_skips_the_prompt_and_proceeds(tmp_path, monkeypatch):
+    """args.force True -> "not force" False, the and is False, no
+    prompt -- proceeds straight to deletion regardless of what input()
+    would have returned. Paired with the baseline: only force differs,
+    isolating that half of the and."""
+    remaining = _system_reset_prompt(tmp_path, monkeypatch, force=True, ci=False, response="n")
+    assert "01_tensor" not in remaining
+
+
+def test_ci_skips_the_prompt_and_proceeds(tmp_path, monkeypatch):
+    """args.ci True -> "not ci" False, the and is False, no prompt.
+    Paired with the baseline: only ci differs, isolating that half of
+    the and from force's independent effect."""
+    remaining = _system_reset_prompt(tmp_path, monkeypatch, force=False, ci=True, response="n")
+    assert "01_tensor" not in remaining

--- a/platforms/cli/tests/test_setup_install_and_arch_detection.py
+++ b/platforms/cli/tests/test_setup_install_and_arch_detection.py
@@ -1,0 +1,130 @@
+"""
+MC/DC coverage for SetupCommand.install_packages's Windows-reinstall-skip
+decision and create_virtual_environment's Apple Silicon / Rosetta
+detection decision.
+"""
+
+import platform
+import subprocess
+
+from platforms.cli.cli_platform.setup import SetupCommand
+from platforms.cli.core.config import CLIConfig
+
+# ---------------------------------------------------------------------------
+# is_windows and self._check_package_installed("trentorch")
+# ---------------------------------------------------------------------------
+
+
+def _install_packages(tmp_path, monkeypatch, *, is_windows, trentorch_installed):
+    monkeypatch.setattr(platform, "system", lambda: "Windows" if is_windows else "Linux")
+    cmd = SetupCommand(CLIConfig.from_project_root(tmp_path))
+    # Every essential package already "installed" so the real pip-install
+    # loop for them never runs; trentorch's own status is what this
+    # decision is actually about.
+    monkeypatch.setattr(
+        cmd, "_check_package_installed", lambda name: True if name != "trentorch" else trentorch_installed
+    )
+
+    def fake_run(cmd_args, **kwargs):
+        return subprocess.CompletedProcess(cmd_args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=120, no_color=True)
+    cmd.install_packages()
+    return buf.getvalue()
+
+
+def test_windows_with_trentorch_already_installed_skips_reinstall(tmp_path, monkeypatch):
+    """Baseline: is_windows True, trentorch already installed True ->
+    skips the real pip install -e . step."""
+    out = _install_packages(tmp_path, monkeypatch, is_windows=True, trentorch_installed=True)
+    assert "skipping reinstall on Windows" in out
+
+
+def test_windows_without_trentorch_installed_does_not_skip(tmp_path, monkeypatch):
+    """is_windows True, trentorch not installed False -> the and is
+    False, proceeds to the real install step instead of skipping.
+    Paired with the baseline: only trentorch's install status differs,
+    isolating that half of the and."""
+    out = _install_packages(tmp_path, monkeypatch, is_windows=True, trentorch_installed=False)
+    assert "skipping reinstall on Windows" not in out
+    assert "Tiny🔥Torch installed" in out
+
+
+def test_non_windows_with_trentorch_installed_does_not_skip(tmp_path, monkeypatch):
+    """is_windows False -> the and is False regardless of trentorch's
+    install status (the WinError 32 file-lock problem this skip exists
+    for is Windows-specific). Paired with the baseline: only is_windows
+    differs, isolating that half of the and."""
+    out = _install_packages(tmp_path, monkeypatch, is_windows=False, trentorch_installed=True)
+    assert "skipping reinstall on Windows" not in out
+    assert "Tiny🔥Torch installed" in out
+
+
+# ---------------------------------------------------------------------------
+# platform.system() == "Darwin" and arch == "x86_64"
+# ---------------------------------------------------------------------------
+
+
+def _create_venv_arch_check(tmp_path, monkeypatch, *, system, arch, sysctl_output=None):
+    monkeypatch.setattr(platform, "system", lambda: system)
+    monkeypatch.setattr(platform, "machine", lambda: arch)
+
+    # setup.py's create_virtual_environment does `import subprocess as sp`
+    # locally to run the sysctl hardware check, and also uses the
+    # module-level `subprocess.run` (imported at the top of this test file)
+    # to actually create the venv -- both names resolve to the exact same
+    # module object, so one dispatching fake has to serve both call sites;
+    # monkeypatching them separately would just have the second overwrite
+    # the first.
+    def fake_run(cmd_args, **kwargs):
+        if isinstance(cmd_args, list) and cmd_args and cmd_args[0] == "sysctl":
+            if sysctl_output is not None:
+                return subprocess.CompletedProcess(cmd_args, returncode=0, stdout=sysctl_output)
+            return subprocess.CompletedProcess(cmd_args, returncode=1, stdout="")
+        return subprocess.CompletedProcess(cmd_args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cmd = SetupCommand(CLIConfig.from_project_root(tmp_path))
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=120, no_color=True)
+    cmd.create_virtual_environment(force=False)
+    return buf.getvalue()
+
+
+def test_darwin_with_x86_64_checks_for_rosetta(tmp_path, monkeypatch):
+    """Baseline: system == "Darwin" True, arch == "x86_64" True -> the
+    Rosetta-detection hardware check runs (sysctl.proc_translated)."""
+    out = _create_venv_arch_check(
+        tmp_path, monkeypatch, system="Darwin", arch="x86_64", sysctl_output="Apple M1\n"
+    )
+    # Detecting Rosetta re-targets to arm64; the console reports it.
+    assert "Rosetta" in out
+
+
+def test_darwin_with_arm64_skips_rosetta_check(tmp_path, monkeypatch):
+    """system == "Darwin" True, arch == "x86_64" False (already native
+    arm64) -> the and is False, no Rosetta re-check needed. Paired with
+    the baseline: only the reported arch differs, isolating that half of
+    the and."""
+    out = _create_venv_arch_check(tmp_path, monkeypatch, system="Darwin", arch="arm64")
+    assert "Creating virtual environment" in out
+
+
+def test_non_darwin_skips_rosetta_check_regardless_of_arch(tmp_path, monkeypatch):
+    """system == "Darwin" is False -> the and is False regardless of
+    arch (Rosetta is a macOS-specific concept). Paired with the
+    baseline: only the platform differs, isolating that half of the and."""
+    out = _create_venv_arch_check(tmp_path, monkeypatch, system="Linux", arch="x86_64")
+    assert "Creating virtual environment" in out

--- a/platforms/cli/tests/test_update_core_init_copy.py
+++ b/platforms/cli/tests/test_update_core_init_copy.py
@@ -1,0 +1,50 @@
+"""
+MC/DC coverage for UpdateCommand._update_tinytorch_package's core/
+__init__.py copy decision: src_core.exists() and dst_core.exists().
+"""
+
+from platforms.cli.cli_platform.system.update import UpdateCommand
+from platforms.cli.core.config import CLIConfig
+
+
+def _update_package(tmp_path, *, src_core_exists, dst_core_exists):
+    src_pkg = tmp_path / "src_pkg"
+    dst_pkg = tmp_path / "dst_pkg"
+    src_pkg.mkdir()
+    dst_pkg.mkdir()
+
+    if src_core_exists:
+        (src_pkg / "core").mkdir()
+        (src_pkg / "core" / "__init__.py").write_text("# new version", encoding="utf-8")
+    if dst_core_exists:
+        (dst_pkg / "core").mkdir()
+        (dst_pkg / "core" / "__init__.py").write_text("# old version", encoding="utf-8")
+
+    cmd = UpdateCommand(CLIConfig.from_project_root(tmp_path))
+    cmd._update_tinytorch_package(src_pkg, dst_pkg)
+    dst_init = dst_pkg / "core" / "__init__.py"
+    return dst_init.read_text(encoding="utf-8") if dst_init.exists() else None
+
+
+def test_both_core_dirs_exist_copies_init(tmp_path):
+    """Baseline: src_core.exists() True, dst_core.exists() True ->
+    core/__init__.py copied over."""
+    result = _update_package(tmp_path, src_core_exists=True, dst_core_exists=True)
+    assert result == "# new version"
+
+
+def test_missing_source_core_dir_does_not_copy(tmp_path):
+    """src_core.exists() False -> the and is False, nothing copied.
+    Paired with the baseline: only src_core's existence differs,
+    isolating that half of the and."""
+    result = _update_package(tmp_path, src_core_exists=False, dst_core_exists=True)
+    assert result == "# old version"  # untouched
+
+
+def test_missing_destination_core_dir_does_not_crash_or_copy(tmp_path):
+    """dst_core.exists() False -> the and is False, nothing copied (and
+    no attempt to write into a directory that doesn't exist). Paired
+    with the baseline: only dst_core's existence differs, isolating that
+    half of the and."""
+    result = _update_package(tmp_path, src_core_exists=True, dst_core_exists=False)
+    assert result is None


### PR DESCRIPTION
## Scope

Closes out the "deliberately incomplete" list from #60: `milestone/command.py`, the rest of `milestone/system.py` and `display.py`, `dev/preflight.py`, `setup.py`, `package/reset.py`, `system/reset.py`, `health.py`, `info.py`, `update.py`, `console.py`'s logo coloring, and `jupyter_magic.py`'s kernel-shutdown branch. Every compound decision on that list now has real MC/DC coverage — same discipline as #59/#60, each test docstring states which pair of cases isolates which condition.

## Two more real bugs found while writing these tests

**1. `dev/preflight.py`'s module-count check could crash the whole preflight run.** If `data/modules` exists as a plain file instead of a directory, the required-directories loop a few dozen lines earlier already detects and reports that exact state as a `FAIL` — it checks `path.exists() and path.is_dir()`. But the later module-count check only checked `modules_dir.exists()` before calling `.iterdir()` on it, which raises `NotADirectoryError` on a file rather than a directory. Found by writing the same "exists but is a file" MC/DC case for the module-count check that the earlier loop already needed. Fixed by checking `.is_dir()` there too.

**2. `milestone/command.py` had a fourth dead condition** (matching the two in #60): `if args.part is not None and len(script_configs) == 1:` gated whether the missing-modules error message names the specific part. Every code path that leaves `script_configs` longer than one element only runs when `args.part` is already `None` — so `len(script_configs) == 1` could never independently be `False` once `args.part is not None` is `True`. Found the same way as before: trying to write the MC/DC pair for it and finding no input could isolate it. Simplified to just `args.part is not None`.

## A note on the riskiest test in this sweep

`jupyter_magic.py`'s `%exit` decision has a real `os._exit(0)` in its false branch — immediate process termination, no exception, no pytest report if the mock is wrong. `os._exit` is monkeypatched before any other side-effecting call in every test that touches it; the full suite (1154 tests) completing afterward confirms the mock held.

## Verification

- Full local suite: 1154 passed / 2 failed, same two pre-existing unrelated failures documented in `docs/testing-strategy.md`, up from 1075/2 after #60 (+79 new tests).
- `ruff check .` and `ruff format --check .` both clean.
- All 7-stage pipeline + Ruff + CodeQL green before merge (see checks below).

With this, every decision flagged across the two AST scans (#60's and this one) in `platforms/cli/` has real MC/DC coverage or an explicit, honest note on why not (`main.py`'s Windows-detection copy, documented in #60, isn't safely testable via reload without a refactor first).
