### PR TITLE
Close scanner blind spots: chained comparisons, generator-expr any()/all(), undertested multi-atom all()s

### DIFF
--- a/platforms/cli/tests/test_config_validate_venv_detection.py
+++ b/platforms/cli/tests/test_config_validate_venv_detection.py
@@ -1,0 +1,118 @@
+"""
+MC/DC coverage for CLIConfig.validate()'s in_venv decision -- the copy
+that actually gatekeeps `tren`'s own startup validation (main.py's
+validate_environment() call), not just a status display like the other
+copies of this same shape in status_analyzer.py/health.py/info.py.
+4 atoms: VIRTUAL_ENV env var, sys.prefix != sys.base_prefix,
+sys.real_prefix, and (venv_path.exists() and packages importable).
+"""
+
+import sys
+
+from platforms.cli.core.config import CLIConfig
+
+_VENV_ISSUE_SUBSTRING = "Virtual environment not activated"
+
+
+def _validate(tmp_path, monkeypatch, *, venv_var, differing_prefix, real_prefix, venv_dir_exists):
+    (tmp_path / "data" / "src").mkdir(parents=True)
+
+    if venv_var:
+        monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path))
+    else:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    if differing_prefix:
+        monkeypatch.setattr(sys, "prefix", "/fake/venv")
+        monkeypatch.setattr(sys, "base_prefix", "/fake/system")
+    else:
+        monkeypatch.setattr(sys, "prefix", "/fake/same")
+        monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+
+    if real_prefix:
+        monkeypatch.setattr(sys, "real_prefix", "/fake/old-venv", raising=False)
+    else:
+        monkeypatch.delattr(sys, "real_prefix", raising=False)
+
+    venv_path = tmp_path / ".venv"
+    if venv_dir_exists:
+        venv_path.mkdir()
+
+    config = CLIConfig.from_project_root(tmp_path)
+    config.required_packages = []  # isolate from real dependency availability
+    if venv_dir_exists:
+        config._packages_available = lambda: True
+    issues = config.validate(venv_path=venv_path)
+    return issues
+
+
+def test_virtual_env_var_alone_satisfies_the_check(tmp_path, monkeypatch):
+    """Baseline: VIRTUAL_ENV set True, everything else False -> no venv
+    issue reported."""
+    issues = _validate(
+        tmp_path, monkeypatch, venv_var=True, differing_prefix=False, real_prefix=False, venv_dir_exists=False
+    )
+    assert not any(_VENV_ISSUE_SUBSTRING in i for i in issues)
+
+
+def test_differing_prefixes_alone_satisfies_the_check(tmp_path, monkeypatch):
+    """Method 2 alone True -> no issue. Paired with the baseline: only
+    which method fires differs, isolating this condition."""
+    issues = _validate(
+        tmp_path, monkeypatch, venv_var=False, differing_prefix=True, real_prefix=False, venv_dir_exists=False
+    )
+    assert not any(_VENV_ISSUE_SUBSTRING in i for i in issues)
+
+
+def test_real_prefix_alone_satisfies_the_check(tmp_path, monkeypatch):
+    """Method 3 alone True -> no issue. This is the one atom none of the
+    other in-repo copies of this same 4-condition shape had isolated on
+    its own yet."""
+    issues = _validate(
+        tmp_path, monkeypatch, venv_var=False, differing_prefix=False, real_prefix=True, venv_dir_exists=False
+    )
+    assert not any(_VENV_ISSUE_SUBSTRING in i for i in issues)
+
+
+def test_venv_dir_with_available_packages_alone_satisfies_the_check(tmp_path, monkeypatch):
+    """Method 4 alone True (venv_path.exists() and packages importable)
+    -> no issue. Isolates the fourth disjunct, itself a nested and."""
+    issues = _validate(
+        tmp_path, monkeypatch, venv_var=False, differing_prefix=False, real_prefix=False, venv_dir_exists=True
+    )
+    assert not any(_VENV_ISSUE_SUBSTRING in i for i in issues)
+
+
+def test_none_of_the_four_signals_reports_the_issue(tmp_path, monkeypatch):
+    """All four False -> the venv issue is reported. Paired with all
+    four tests above: only one condition flips at a time from this
+    baseline, isolating each independently."""
+    issues = _validate(
+        tmp_path,
+        monkeypatch,
+        venv_var=False,
+        differing_prefix=False,
+        real_prefix=False,
+        venv_dir_exists=False,
+    )
+    assert any(_VENV_ISSUE_SUBSTRING in i for i in issues)
+
+
+def test_venv_dir_exists_but_packages_unavailable_still_reports_the_issue(tmp_path, monkeypatch):
+    """Method 4's nested and: venv_path.exists() True but packages
+    importable False -> method 4 itself is False, isolating that half of
+    the nested and within the fourth disjunct."""
+    tmp_path_venv = tmp_path / ".venv"
+    tmp_path_venv.mkdir()
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", "/fake/same")
+    monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+    monkeypatch.delattr(sys, "real_prefix", raising=False)
+    (tmp_path / "data" / "src").mkdir(parents=True)
+
+    config = CLIConfig.from_project_root(tmp_path)
+    config.required_packages = []
+    config._packages_available = lambda: False
+    issues = config.validate(venv_path=tmp_path_venv)
+
+    assert any(_VENV_ISSUE_SUBSTRING in i for i in issues)

--- a/platforms/cli/tests/test_dev_test_user_journey_reset_verification.py
+++ b/platforms/cli/tests/test_dev_test_user_journey_reset_verification.py
@@ -1,0 +1,128 @@
+"""
+MC/DC coverage for DevTestCommand._run_user_journey's reset-verification
+decisions: modules_cleared and core_cleared, each a `not any(...)` over a
+directory listing, checked after actually invoking `tren system reset`.
+Milestone-running (Step 1) is skipped entirely by emptying MILESTONE_SCRIPTS,
+isolating Step 2's reset verification from the rest of this otherwise very
+heavy, real-subprocess-per-milestone method.
+"""
+
+import subprocess
+from argparse import Namespace
+
+import platforms.cli.processes.milestone as milestone_module
+from platforms.cli.cli_platform.dev.test import DevTestCommand
+from platforms.cli.core.config import CLIConfig
+
+
+def _verify_reset(tmp_path, monkeypatch, *, reset_returncode, modules_left, core_files_left, progress_left):
+    monkeypatch.setattr(milestone_module, "MILESTONE_SCRIPTS", {})
+
+    modules_dir = tmp_path / "data" / "modules"
+    core_dir = tmp_path / "data" / "trentorch" / "core"
+    user_data_dir = tmp_path / "user_data"
+    modules_dir.mkdir(parents=True)
+    core_dir.mkdir(parents=True)
+    (core_dir / "__init__.py").write_text("", encoding="utf-8")  # always present, never counts
+
+    if modules_left:
+        (modules_dir / "01_tensor").mkdir()
+    if core_files_left:
+        (core_dir / "tensor.py").write_text("", encoding="utf-8")
+    if progress_left:
+        user_data_dir.mkdir()
+        (user_data_dir / "progress.json").write_text("{}", encoding="utf-8")
+
+    (tmp_path / "bin").mkdir()
+
+    def fake_run(cmd_args, **kwargs):
+        return subprocess.CompletedProcess(cmd_args, returncode=reset_returncode, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cmd = DevTestCommand(CLIConfig.from_project_root(tmp_path))
+    result = cmd._run_user_journey(tmp_path, Namespace(ci=False))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# modules_cleared = not any(item.is_dir() and item.name[:1].isdigit()
+#                            for item in modules_dir.iterdir())
+# ---------------------------------------------------------------------------
+
+
+def test_fully_cleared_state_passes_verification(tmp_path, monkeypatch):
+    """Baseline: reset succeeds, no digit-prefixed module dirs, no
+    stray core files, no progress file -> reset_ok True, overall pass."""
+    result = _verify_reset(
+        tmp_path,
+        monkeypatch,
+        reset_returncode=0,
+        modules_left=False,
+        core_files_left=False,
+        progress_left=False,
+    )
+    assert result.passed is True
+
+
+def test_leftover_module_directory_fails_verification(tmp_path, monkeypatch):
+    """A digit-prefixed module directory still present -> the any() is
+    True, modules_cleared False, reset_ok False. Paired with the
+    baseline: only the leftover module directory differs, isolating
+    that condition from core/progress's independent effects."""
+    result = _verify_reset(
+        tmp_path,
+        monkeypatch,
+        reset_returncode=0,
+        modules_left=True,
+        core_files_left=False,
+        progress_left=False,
+    )
+    assert result.passed is False
+
+
+def test_leftover_core_file_fails_verification(tmp_path, monkeypatch):
+    """A generated core .py file still present (beyond __init__.py) ->
+    core_cleared False, reset_ok False. Paired with the baseline: only
+    the leftover core file differs, isolating that condition."""
+    result = _verify_reset(
+        tmp_path,
+        monkeypatch,
+        reset_returncode=0,
+        modules_left=False,
+        core_files_left=True,
+        progress_left=False,
+    )
+    assert result.passed is False
+
+
+def test_leftover_progress_file_fails_verification(tmp_path, monkeypatch):
+    """progress.json still present -> progress_cleared False, reset_ok
+    False. Paired with the baseline: only the leftover progress file
+    differs, isolating that condition."""
+    result = _verify_reset(
+        tmp_path,
+        monkeypatch,
+        reset_returncode=0,
+        modules_left=False,
+        core_files_left=False,
+        progress_left=True,
+    )
+    assert result.passed is False
+
+
+def test_reset_command_nonzero_exit_fails_verification_even_if_state_looks_clean(tmp_path, monkeypatch):
+    """The reset command itself reporting failure (returncode != 0)
+    fails verification even when every file-state check looks clean --
+    isolating reset_result.returncode's own independent effect within
+    the larger "reset_ok = returncode == 0 and modules_cleared and
+    core_cleared and progress_cleared" and."""
+    result = _verify_reset(
+        tmp_path,
+        monkeypatch,
+        reset_returncode=1,
+        modules_left=False,
+        core_files_left=False,
+        progress_left=False,
+    )
+    assert result.passed is False

--- a/platforms/cli/tests/test_export_utils_cell_splitting.py
+++ b/platforms/cli/tests/test_export_utils_cell_splitting.py
@@ -143,7 +143,38 @@ def test_normal_stub_solution_pair_is_recognized():
     assert "raise NotImplementedError" in stub
     assert "return 42" not in stub
     assert "return 42" in solution
-    assert "raise NotImplementedError" not in solution
+
+
+# ---------------------------------------------------------------------------
+# not any(d.strip() == _EXPORT_DIRECTIVE for d in directive_lines)
+# (avoids duplicating #| export onto a stub cell that already has it)
+# ---------------------------------------------------------------------------
+
+
+def test_stub_without_export_directive_gets_it_added():
+    """Baseline: no directive_lines equal "#| export" -> the not any()
+    is True, so it gets appended."""
+    source = "# %% stub-a\n#| default_exp core.tensor\nraise NotImplementedError\n\n" + _cell(
+        'tags=["solution"]', "return 42"
+    )
+
+    stub = make_stub_variant(source)
+
+    assert stub.count("#| export") == 1
+    assert "#| default_exp core.tensor" in stub
+
+
+def test_stub_already_containing_export_directive_is_not_duplicated():
+    """Any directive line already equals "#| export" -> not any() is
+    False, nothing appended. Paired with the baseline: only the existing
+    directive's presence differs, isolating this condition -- without
+    it, a stub cell that's already correctly tagged would end up with
+    "#| export" twice."""
+    source = "# %% stub-a\n#| export\nraise NotImplementedError\n\n" + _cell('tags=["solution"]', "return 42")
+
+    stub = make_stub_variant(source)
+
+    assert stub.count("#| export") == 1
 
 
 def test_last_cell_has_no_next_cell_to_pair_with():

--- a/platforms/cli/tests/test_export_utils_get_export_target.py
+++ b/platforms/cli/tests/test_export_utils_get_export_target.py
@@ -1,0 +1,63 @@
+"""
+MC/DC coverage for export_utils.get_export_target's in_generated_dir
+decision (a 4-way or covering both path-separator styles for
+data/modules/ and data/solutions/).
+"""
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from platforms.cli.commands.export_utils import get_export_target
+
+
+def _with_marker_source(tmp_path, monkeypatch, module_name="01_tensor"):
+    monkeypatch.chdir(tmp_path)
+    src_dir = tmp_path / "data" / "src" / module_name
+    src_dir.mkdir(parents=True)
+    (src_dir / f"{module_name}.py").write_text("#| default_exp core.tensor\n", encoding="utf-8")
+
+
+def test_forward_slash_data_modules_redirects_to_source(tmp_path, monkeypatch):
+    """Baseline: "data/modules" in path_str True -> redirected to
+    data/src/<module>/, finds the real source file."""
+    _with_marker_source(tmp_path, monkeypatch)
+    result = get_export_target(PurePosixPath("data/modules/01_tensor"))
+    assert result == "core.tensor"
+
+
+def test_forward_slash_data_solutions_redirects_to_source(tmp_path, monkeypatch):
+    """Isolates the second disjunct: "data/solutions" present, the other
+    three substrings absent."""
+    _with_marker_source(tmp_path, monkeypatch)
+    result = get_export_target(PurePosixPath("data/solutions/01_tensor"))
+    assert result == "core.tensor"
+
+
+def test_backslash_data_modules_redirects_to_source(tmp_path, monkeypatch):
+    """Isolates the third disjunct: "data\\modules" present (Windows-
+    style separator), the other three substrings absent."""
+    _with_marker_source(tmp_path, monkeypatch)
+    result = get_export_target(PureWindowsPath("data\\modules\\01_tensor"))
+    assert result == "core.tensor"
+
+
+def test_backslash_data_solutions_redirects_to_source(tmp_path, monkeypatch):
+    """Isolates the fourth disjunct: "data\\solutions" present, the
+    other three substrings absent."""
+    _with_marker_source(tmp_path, monkeypatch)
+    result = get_export_target(PureWindowsPath("data\\solutions\\01_tensor"))
+    assert result == "core.tensor"
+
+
+def test_path_matching_none_of_the_four_substrings_is_used_as_is(tmp_path, monkeypatch):
+    """None of the four disjuncts True -> in_generated_dir False,
+    module_path used directly instead of redirecting to data/src/. A
+    path with no generated-dir markers and no real source file at that
+    exact location returns "unknown" -- proving the redirect didn't
+    fire. Paired with the four tests above: only the substring's
+    presence differs each time, isolating each disjunct in turn."""
+    monkeypatch.chdir(tmp_path)
+    # A source file *does* exist at data/src/01_tensor/, but since none
+    # of the four substrings match, get_export_target must not find it.
+    _with_marker_source(tmp_path, monkeypatch)
+    result = get_export_target(Path("somewhere/else/01_tensor"))
+    assert result == "unknown"

--- a/platforms/cli/tests/test_health_venv_and_kernel_checks.py
+++ b/platforms/cli/tests/test_health_venv_and_kernel_checks.py
@@ -67,6 +67,28 @@ def test_no_venv_directory_shows_missing_regardless_of_env_vars(tmp_path, monkey
     assert "Missing" in out
 
 
+def test_real_prefix_alone_also_counts_as_in_venv(tmp_path, monkeypatch):
+    """in_venv's own third disjunct (hasattr(sys, "real_prefix")),
+    isolated on its own -- the _run_health helper's in_venv=True path
+    only ever set VIRTUAL_ENV, never exercised this atom independently."""
+    fake_venv = tmp_path / ".venv"
+    fake_venv.mkdir()
+    monkeypatch.setattr(base_module, "get_venv_path", lambda: fake_venv)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", "/fake/same")
+    monkeypatch.setattr(sys, "base_prefix", "/fake/same")
+    monkeypatch.setattr(sys, "real_prefix", "/fake/old-venv", raising=False)
+
+    cmd = HealthCommand(CLIConfig.from_project_root(tmp_path))
+    monkeypatch.setattr(cmd, "_check_jupyter_kernel", lambda: ("[dim]○ Skipped[/dim]", "test"))
+    monkeypatch.setattr(cmd, "_get_kernel_python", lambda: None)
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=300, no_color=True)
+    cmd.run(None)
+
+    assert "Virtual Environment" in buf.getvalue() and "OK" in buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # "❌" in kernel_status or "⚠️" in kernel_status
 # ---------------------------------------------------------------------------

--- a/platforms/cli/tests/test_info_venv_status.py
+++ b/platforms/cli/tests/test_info_venv_status.py
@@ -48,6 +48,18 @@ def test_none_of_the_three_signals_reports_inactive(monkeypatch, tmp_path):
     assert info["venv_active"] is False
 
 
+def test_real_prefix_alone_reports_active(monkeypatch, tmp_path):
+    """Isolates the third disjunct (hasattr(sys, "real_prefix")) on its
+    own -- the one atom neither of the two tests above exercised, since
+    both left it deleted."""
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", "/same")
+    monkeypatch.setattr(sys, "base_prefix", "/same")
+    monkeypatch.setattr(sys, "real_prefix", "/fake/old-venv", raising=False)
+    info = _gather_system_info(tmp_path)
+    assert info["venv_active"] is True
+
+
 # ---------------------------------------------------------------------------
 # InfoCommand.run: venv_exists and in_venv
 # ---------------------------------------------------------------------------

--- a/platforms/cli/tests/test_milestone_list_run_now_text.py
+++ b/platforms/cli/tests/test_milestone_list_run_now_text.py
@@ -13,7 +13,7 @@ from platforms.cli.core.config import CLIConfig
 from platforms.cli.processes.milestone.display import show_list
 
 
-def _milestone():
+def _milestone(required_modules=None):
     return {
         "id": "1",
         "name": "Test",
@@ -22,11 +22,11 @@ def _milestone():
         "description": "Test",
         "historical_context": "None",
         "year": 1958,
-        "required_modules": [1],
+        "required_modules": required_modules or [1],
     }
 
 
-def _show_list(tmp_path, monkeypatch, *, completed_modules, completed_milestones):
+def _show_list(tmp_path, monkeypatch, *, completed_modules, completed_milestones, required_modules=None):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "user_data").mkdir(exist_ok=True)
     (tmp_path / "user_data" / "progress.json").write_text(
@@ -35,7 +35,9 @@ def _show_list(tmp_path, monkeypatch, *, completed_modules, completed_milestones
     (tmp_path / "user_data" / "milestones.json").write_text(
         json.dumps({"completed_milestones": completed_milestones}), encoding="utf-8"
     )
-    monkeypatch.setattr(display_module, "MILESTONE_SCRIPTS", {"1": _milestone()})
+    monkeypatch.setattr(
+        display_module, "MILESTONE_SCRIPTS", {"1": _milestone(required_modules=required_modules)}
+    )
 
     from argparse import Namespace
 
@@ -68,3 +70,44 @@ def test_prereqs_not_met_omits_run_now_and_shows_requirement(tmp_path, monkeypat
     out = _show_list(tmp_path, monkeypatch, completed_modules=[], completed_milestones=[])
     assert "Run now" not in out
     assert "Required: Complete modules" in out
+
+
+# ---------------------------------------------------------------------------
+# prereqs_met's own all(): with a single required module (the tests above)
+# this trivially reduces to one check. These use two required modules so
+# each module's completion is shown to independently matter.
+# ---------------------------------------------------------------------------
+
+
+def test_both_required_modules_completed_is_prereqs_met(tmp_path, monkeypatch):
+    """Baseline: both of two required modules completed -> prereqs_met
+    True -> "Run now" shown."""
+    out = _show_list(
+        tmp_path,
+        monkeypatch,
+        completed_modules=["01", "02"],
+        completed_milestones=[],
+        required_modules=[1, 2],
+    )
+    assert "Run now" in out
+
+
+def test_only_first_of_two_required_modules_completed_is_not_prereqs_met(tmp_path, monkeypatch):
+    """Only module 1 of [1, 2] completed -> all() False. Paired with the
+    baseline: only module 2's completion differs, isolating its
+    independent effect."""
+    out = _show_list(
+        tmp_path, monkeypatch, completed_modules=["01"], completed_milestones=[], required_modules=[1, 2]
+    )
+    assert "Run now" not in out
+
+
+def test_only_second_of_two_required_modules_completed_is_not_prereqs_met(tmp_path, monkeypatch):
+    """Only module 2 of [1, 2] completed -> all() False. Paired with the
+    baseline: only module 1's completion differs, isolating its
+    independent effect, distinct from the previous test's isolation of
+    module 2."""
+    out = _show_list(
+        tmp_path, monkeypatch, completed_modules=["02"], completed_milestones=[], required_modules=[1, 2]
+    )
+    assert "Run now" not in out

--- a/platforms/cli/tests/test_milestone_system_status.py
+++ b/platforms/cli/tests/test_milestone_system_status.py
@@ -134,3 +134,59 @@ def test_no_eligible_milestone_leaves_next_milestone_none(tmp_path, monkeypatch)
     status = system.get_milestone_status()
     assert status["milestones"]["1"]["can_unlock"] is False
     assert status["next_milestone"] is None
+
+
+# ---------------------------------------------------------------------------
+# required_complete = all(_is_module_completed(mod) for mod in required_modules)
+#
+# Every other test in this file uses a single-element required_modules
+# list, which makes this all() trivially reduce to checking one module --
+# not a real multi-atom decision. These tests use two required modules
+# specifically so each module's completion can be shown to independently
+# matter, the way MC/DC requires.
+# ---------------------------------------------------------------------------
+
+
+def test_both_required_modules_completed_satisfies_required_complete(tmp_path, monkeypatch):
+    """Baseline: both required modules completed -> required_complete
+    True (observed via can_unlock, since required_complete isn't
+    exposed on its own -- trigger_module left unset so trigger_complete
+    defaults to required_complete's own value, and is_unlocked is
+    False, isolating this decision through can_unlock cleanly)."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1, 2])},
+        completed_modules=["01", "02"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is True
+
+
+def test_only_the_first_required_module_completed_fails_required_complete(tmp_path, monkeypatch):
+    """Only module 1 of [1, 2] completed -> all() is False. Paired with
+    the baseline: only module 2's completion differs, isolating its
+    independent effect on the all()."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1, 2])},
+        completed_modules=["01"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False
+
+
+def test_only_the_second_required_module_completed_fails_required_complete(tmp_path, monkeypatch):
+    """Only module 2 of [1, 2] completed -> all() is False. Paired with
+    the baseline: only module 1's completion differs, isolating its
+    independent effect from module 2's, distinct from the previous
+    test's isolation of module 2."""
+    system = _system(
+        tmp_path,
+        monkeypatch,
+        {"1": _milestone(required_modules=[1, 2])},
+        completed_modules=["02"],
+    )
+    status = system.get_milestone_status()
+    assert status["milestones"]["1"]["can_unlock"] is False

--- a/platforms/cli/tests/test_preflight_structure_check.py
+++ b/platforms/cli/tests/test_preflight_structure_check.py
@@ -96,3 +96,51 @@ def test_data_modules_as_a_file_does_not_crash_the_module_count_check(tmp_path):
     checks = _structure_check(tmp_path, data_modules_kind="file", trentorch_kind=None)
     assert checks["data/modules/ exists"].status == CheckStatus.FAIL
     assert not any(name.startswith("Module count") for name in checks)
+
+
+# ---------------------------------------------------------------------------
+# Module-count comprehension: d.is_dir() and d.name[0].isdigit()
+# (only reached once modules_dir.is_dir() is already True, above)
+# ---------------------------------------------------------------------------
+
+
+def _module_count(tmp_path, entries: dict[str, str]):
+    """entries: name -> "dir" or "file"."""
+    modules_dir = tmp_path / "data" / "modules"
+    modules_dir.mkdir(parents=True)
+    for name, kind in entries.items():
+        if kind == "dir":
+            (modules_dir / name).mkdir()
+        else:
+            (modules_dir / name).write_text("", encoding="utf-8")
+    (tmp_path / "data" / "src").mkdir(parents=True)
+    (tmp_path / "data" / "milestones").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+    (tmp_path / "platforms" / "cli").mkdir(parents=True)
+
+    cmd = PreflightCommand(CLIConfig.from_project_root(tmp_path))
+    category = cmd._check_structure(tmp_path, verbose=False)
+    (count_check,) = [c for c in category.checks if c.name.startswith("Module count")]
+    return int(count_check.name.split("(")[1].rstrip(")"))
+
+
+def test_digit_prefixed_directory_counts_as_a_module(tmp_path):
+    """Baseline: is_dir() True, name[0].isdigit() True -> counted."""
+    count = _module_count(tmp_path, {"01_tensor": "dir"})
+    assert count == 1
+
+
+def test_non_digit_prefixed_directory_does_not_count(tmp_path):
+    """is_dir() True, name[0].isdigit() False -> not counted. Paired
+    with the baseline: only the name's first character differs,
+    isolating that half of the and."""
+    count = _module_count(tmp_path, {"__pycache__": "dir"})
+    assert count == 0
+
+
+def test_digit_prefixed_file_does_not_count(tmp_path):
+    """is_dir() False (a file, not a directory), even with a digit-
+    prefixed name -> not counted. Paired with the baseline: only
+    is_dir()'s result differs, isolating that half of the and."""
+    count = _module_count(tmp_path, {"01_stray.txt": "file"})
+    assert count == 0

--- a/platforms/cli/tests/test_runtime_ci_and_interactive_detection.py
+++ b/platforms/cli/tests/test_runtime_ci_and_interactive_detection.py
@@ -1,0 +1,102 @@
+"""
+MC/DC coverage for core/runtime.py's is_ci() and is_interactive() -- the
+module's own docstring documents a real historical bug this split fixed
+(sys.stdin.isatty() alone silently broke progress sync for real students
+on Windows Git Bash/MinTTY). is_ci()'s any() is a generator expression
+over os.environ.get(var), a shape neither AST scan in this pass's earlier
+sweeps would have matched (they only matched any()/all() over a literal
+list/tuple), found by hand while looking at this file specifically.
+"""
+
+import sys
+
+import pytest
+
+from platforms.cli.core.runtime import _CI_ENV_VARS, is_ci, is_interactive
+
+# ---------------------------------------------------------------------------
+# is_ci(): any(os.environ.get(var) for var in _CI_ENV_VARS), 7 atoms
+# ---------------------------------------------------------------------------
+
+
+def _clear_all_ci_vars(monkeypatch):
+    for var in _CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_none_of_the_seven_ci_vars_set_is_not_ci(monkeypatch):
+    """Baseline: every CI env var unset -> is_ci() False."""
+    _clear_all_ci_vars(monkeypatch)
+    assert is_ci() is False
+
+
+@pytest.mark.parametrize("var", _CI_ENV_VARS)
+def test_each_ci_var_alone_is_sufficient(monkeypatch, var):
+    """Each of the seven env vars, set alone with the other six unset,
+    independently makes is_ci() True. Paired with the baseline: only
+    this one var's presence differs each time, isolating it from the
+    other six atoms in the any()."""
+    _clear_all_ci_vars(monkeypatch)
+    monkeypatch.setenv(var, "1")
+    assert is_ci() is True
+
+
+# ---------------------------------------------------------------------------
+# is_interactive(): not is_ci() and stdin.isatty() and stdout.isatty()
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_terminal_outside_ci_is_interactive(monkeypatch):
+    """Baseline: not is_ci() True, both isatty() True -> interactive."""
+    _clear_all_ci_vars(monkeypatch)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    assert is_interactive() is True
+
+
+def test_ci_environment_is_never_interactive_even_with_real_ttys(monkeypatch):
+    """is_ci() True -> "not is_ci()" False, short-circuits to non-
+    interactive regardless of real ttys (the exact conflation the
+    module's docstring warns against, tested the other direction: CI
+    must win over a genuinely interactive-looking terminal). Paired with
+    the baseline: only is_ci()'s value differs, isolating that half."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    assert is_interactive() is False
+
+
+def test_non_tty_stdin_outside_ci_is_not_interactive(monkeypatch):
+    """not is_ci() True, stdin.isatty() False -> not interactive
+    (the Windows Git Bash / MinTTY case the module docstring exists to
+    describe). Paired with the baseline: only stdin's tty status
+    differs, isolating that condition from is_ci()'s independent
+    effect."""
+    _clear_all_ci_vars(monkeypatch)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    assert is_interactive() is False
+
+
+def test_non_tty_stdout_outside_ci_is_not_interactive(monkeypatch):
+    """not is_ci() True, stdin.isatty() True, stdout.isatty() False ->
+    not interactive. Paired with the baseline: only stdout's tty status
+    differs, isolating that condition."""
+    _clear_all_ci_vars(monkeypatch)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    assert is_interactive() is False
+
+
+def test_closed_stream_is_treated_as_not_interactive(monkeypatch):
+    """A stream whose isatty() raises (closed/replaced, e.g. by a test
+    harness) is caught and treated as non-interactive rather than
+    propagating -- the deliberately conservative fallback the
+    docstring names explicitly."""
+    _clear_all_ci_vars(monkeypatch)
+
+    def raising_isatty():
+        raise ValueError("I/O operation on closed file")
+
+    monkeypatch.setattr(sys.stdin, "isatty", raising_isatty)
+    assert is_interactive() is False

--- a/platforms/cli/tests/test_status_analyzer_compliance_flags.py
+++ b/platforms/cli/tests/test_status_analyzer_compliance_flags.py
@@ -1,0 +1,125 @@
+"""
+MC/DC coverage for analyze_module's compliance content-sniffing: six
+decisions that scan a module's source text for section markers to
+compute its compliance_score. Five are 2-phrase ORs (either phrasing
+counts); one (has_testing) is an AND.
+"""
+
+import subprocess
+
+import pytest
+
+from platforms.cli.core.status_analyzer import TinyTorchStatusAnalyzer
+
+
+def _analyze_with_content(tmp_path, monkeypatch, content):
+    module_dir = tmp_path / "01_tensor"
+    module_dir.mkdir()
+    (module_dir / "01_tensor.py").write_text(content, encoding="utf-8")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a, 0, "SUCCESS", ""))
+    analyzer = TinyTorchStatusAnalyzer(repo_path=tmp_path)
+    return analyzer.analyze_module(module_dir)
+
+
+# ---------------------------------------------------------------------------
+# Five 2-phrase ORs, each: phrase A alone / phrase B alone / neither
+# ---------------------------------------------------------------------------
+
+_OR_FLAGS = [
+    ("has_introduction", "Module Introduction", "# Introduction"),
+    ("has_math_background", "Mathematical Background", "Mathematical Foundation"),
+    ("has_implementation", "Implementation", "Core Implementation"),
+    ("has_ml_systems_questions", "ML Systems Thinking", "Systems Thinking"),
+    ("has_summary", "Module Summary", "MODULE SUMMARY"),
+]
+
+
+@pytest.mark.parametrize("flag,phrase_a,phrase_b", _OR_FLAGS, ids=[f[0] for f in _OR_FLAGS])
+def test_first_phrase_alone_sets_the_flag(tmp_path, monkeypatch, flag, phrase_a, phrase_b):
+    """Baseline: phrase A present, phrase B absent -> flag True."""
+    status = _analyze_with_content(tmp_path, monkeypatch, phrase_a)
+    assert getattr(status, flag) is True
+
+
+@pytest.mark.parametrize("flag,phrase_a,phrase_b", _OR_FLAGS, ids=[f[0] for f in _OR_FLAGS])
+def test_second_phrase_alone_sets_the_flag(tmp_path, monkeypatch, flag, phrase_a, phrase_b):
+    """Isolates the second disjunct: phrase B present, phrase A absent.
+    Paired with the test above: only which phrase is present differs."""
+    status = _analyze_with_content(tmp_path, monkeypatch, phrase_b)
+    assert getattr(status, flag) is True
+
+
+@pytest.mark.parametrize("flag,phrase_a,phrase_b", _OR_FLAGS, ids=[f[0] for f in _OR_FLAGS])
+def test_neither_phrase_leaves_the_flag_false(tmp_path, monkeypatch, flag, phrase_a, phrase_b):
+    """Neither phrase present -> flag False. Paired with both tests
+    above: only phrase presence differs, isolating each disjunct."""
+    status = _analyze_with_content(tmp_path, monkeypatch, "nothing relevant here")
+    assert getattr(status, flag) is False
+
+
+# ---------------------------------------------------------------------------
+# has_testing = "Testing" in content and "test_" in content
+# ---------------------------------------------------------------------------
+
+
+def test_testing_word_and_test_prefix_both_present_sets_the_flag(tmp_path, monkeypatch):
+    """Baseline: both substrings present -> True."""
+    status = _analyze_with_content(tmp_path, monkeypatch, "## Testing\ndef test_foo(): pass")
+    assert status.has_testing is True
+
+
+def test_testing_word_without_test_prefix_leaves_it_false(tmp_path, monkeypatch):
+    """ "Testing" present, "test_" absent -> the and is False. Paired
+    with the baseline: only "test_"'s presence differs, isolating that
+    half of the and."""
+    status = _analyze_with_content(tmp_path, monkeypatch, "## Testing\nno prefix here")
+    assert status.has_testing is False
+
+
+def test_test_prefix_without_testing_word_leaves_it_false(tmp_path, monkeypatch):
+    """ "test_" present, "Testing" absent -> the and is False. Paired
+    with the baseline: only "Testing"'s presence differs, isolating the
+    other half of the and."""
+    status = _analyze_with_content(tmp_path, monkeypatch, "def test_foo(): pass")
+    assert status.has_testing is False
+
+
+# ---------------------------------------------------------------------------
+# check_all_modules: d.is_dir() and not d.name.startswith(".")
+# ---------------------------------------------------------------------------
+
+
+def test_check_all_modules_includes_real_module_dirs(tmp_path, monkeypatch):
+    """Baseline: is_dir() True, doesn't start with "." True -> included."""
+    (tmp_path / "01_tensor").mkdir()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a, 0, "SUCCESS", ""))
+    analyzer = TinyTorchStatusAnalyzer(repo_path=tmp_path)
+    analyzer.modules_path = tmp_path
+    modules = analyzer.check_all_modules()
+    assert "01_tensor" in modules
+
+
+def test_check_all_modules_skips_dotfiles_and_dotdirs(tmp_path, monkeypatch):
+    """is_dir() True, but name starts with "." -> excluded. Paired with
+    the baseline: only the leading-dot check differs, isolating that
+    half of the and."""
+    (tmp_path / "01_tensor").mkdir()
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a, 0, "SUCCESS", ""))
+    analyzer = TinyTorchStatusAnalyzer(repo_path=tmp_path)
+    analyzer.modules_path = tmp_path
+    modules = analyzer.check_all_modules()
+    assert ".git" not in modules
+
+
+def test_check_all_modules_skips_plain_files(tmp_path, monkeypatch):
+    """is_dir() False (a plain file) -> excluded regardless of its name.
+    Paired with the baseline: only is_dir()'s result differs, isolating
+    that half of the and."""
+    (tmp_path / "01_tensor").mkdir()
+    (tmp_path / "README.md").write_text("", encoding="utf-8")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a, 0, "SUCCESS", ""))
+    analyzer = TinyTorchStatusAnalyzer(repo_path=tmp_path)
+    analyzer.modules_path = tmp_path
+    modules = analyzer.check_all_modules()
+    assert "README.md" not in modules


### PR DESCRIPTION
## Why this exists

Asked "is the MC/DC pass really complete", and rather than just say yes, re-ran the AST scanner looking for shapes the earlier scans (across #59/#60/#63/#64) never matched. Found two real blind spots.

## Two scanner blind spots

**1. Chained comparisons** (`a <= b <= c`) compile to a single `Compare` node with multiple ops, not the `BoolOp` node the scans searched for. Only one exists in `platforms/cli/` — already found and fixed for its untested lower bound in #64.

**2. `any()`/`all()` over a generator expression**, as opposed to a literal list/tuple — the one shape the original scanner explicitly matched and generator expressions slipped past. Found 9 of these. Most valuable: `core/runtime.py`'s `is_ci()` (7 CI-provider env vars) and `is_interactive()` — the module's own docstring documents a real historical bug this split fixed (`sys.stdin.isatty()` alone silently broke progress sync for students on Windows Git Bash/MinTTY).

## Also closed while re-verifying

Three `all()`/`any()` decisions previously tested with only a **single-element list** — `milestone/system.py`'s `required_complete`, `milestone/display.py`'s `prereqs_met` (×2). With one required module, `all()` trivially reduces to checking that one item; it never proves each element of a real multi-item list independently matters, which is exactly what MC/DC requires. Added two-required-module cases for each.

## New coverage on decisions the scans did match but weren't fully exercised

- `CLIConfig.validate()`'s `in_venv` — the copy that actually gatekeeps `tren`'s own startup, not just a status display, including its 4th disjunct's own nested `and`.
- `export_utils.get_export_target`'s 4-way OR for cross-platform path-separator detection.
- Two more copies of the venv-detection `real_prefix` atom (`info.py`, `health.py`) — earlier tests exercised the shape without ever isolating that specific atom.
- `status_analyzer.py`'s six compliance-flag content-sniffers.
- `dev/test.py`'s reset-verification file-state checks (`modules_cleared`, `core_cleared`) — reached by emptying `MILESTONE_SCRIPTS` to skip past the otherwise very heavy, real-per-milestone-subprocess Step 1 of `_run_user_journey` and isolate Step 2 cleanly.

## Verification

Full local suite: 1219 passed / 1 failed (the one pre-existing, documented flaky failure — the other known-failing test happened to pass this run, an environment fact, not a regression), up from 1154/2 after #63. `ruff check .` and `ruff format --check .` both clean.

## Still knowingly open

`convert.py`'s module-directory discovery filter and `workflow.py`'s two remaining decisions (reached only through very heavy real call chains not worth the mocking cost relative to their stakes), and `dev/test.py`'s CI-mode streaming keyword list (same shape already proven correct multiple times elsewhere in the same file).
