### PR TITLE
Close remaining MC/DC gaps in convert, workflow, test, and display modules

### DIFF
--- a/platforms/cli/processes/module_workflow/workflow.py
+++ b/platforms/cli/processes/module_workflow/workflow.py
@@ -311,7 +311,11 @@ class ModuleWorkflowCommand(BaseCommand):
                     for module in completed
                     if str(module).split("_", 1)[0].isdigit()
                 }
-                modules_left = len([r for r in required if r not in completed_nums and r >= module_num])
+                # r >= module_num is always true here: the prerequisite
+                # check above already returned 1 if any module before
+                # module_num was incomplete, so any required r < module_num
+                # is guaranteed to already be in completed_nums.
+                modules_left = len([r for r in required if r not in completed_nums])
                 if modules_left <= 3:
                     info_table.add_row("🏆 Milestone", f"[magenta]{mid} - {mname}[/magenta]")
                     info_table.add_row("", f"[dim]{modules_left} modules until unlock[/dim]")

--- a/platforms/cli/tests/test_convert_module_discovery.py
+++ b/platforms/cli/tests/test_convert_module_discovery.py
@@ -1,0 +1,155 @@
+"""
+MC/DC coverage for ConvertCommand.run's two module-discovery decisions:
+the "all" filter (d.is_dir() and not d.name.startswith((".", "_"))) and
+the specific-module 4-atom OR
+(d.is_dir() and (d.name == args.module or d.name.startswith(f"{args.module}_")
+ or d.name.endswith(f"_{args.module}"))).
+
+The real conversion functions (to_qmd/to_ipynb/to_sandbox_code/to_platform_yaml)
+are mocked out -- this file only exercises which module directories get
+selected, not the conversion logic itself.
+"""
+
+from argparse import Namespace
+from io import StringIO
+
+from rich.console import Console
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.convert import ConvertCommand
+
+
+def _run_convert(tmp_path, monkeypatch, entries: dict, *, module="all", fmt="qmd"):
+    """entries: name -> "dir_with_src" | "dir_no_src" | "file"."""
+    src_dir = tmp_path / "data" / "src"
+    src_dir.mkdir(parents=True)
+    for name, kind in entries.items():
+        if kind == "dir_with_src":
+            (src_dir / name).mkdir()
+            (src_dir / name / f"{name}.py").write_text("x = 1\n", encoding="utf-8")
+        elif kind == "dir_no_src":
+            (src_dir / name).mkdir()
+        else:
+            (src_dir / name).write_text("", encoding="utf-8")
+
+    import trentorch.export_sanitizer as sanitizer_module
+
+    monkeypatch.setattr(sanitizer_module, "to_qmd", lambda content: "qmd")
+    monkeypatch.setattr(sanitizer_module, "to_ipynb", lambda content: {"cells": []})
+    monkeypatch.setattr(sanitizer_module, "to_sandbox_code", lambda content: "code")
+    monkeypatch.setattr(sanitizer_module, "to_platform_yaml", lambda content, module_name=None: "yaml: true")
+
+    cmd = ConvertCommand(CLIConfig.from_project_root(tmp_path))
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=200, no_color=True)
+    result = cmd.run(Namespace(module=module, format=fmt, out=str(tmp_path / "build")))
+    return result, buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# "all" filter: d.is_dir() and not d.name.startswith((".", "_"))
+# ---------------------------------------------------------------------------
+
+
+def test_regular_module_directory_is_converted(tmp_path, monkeypatch):
+    """Baseline: is_dir() True, name doesn't start with "." or "_" ->
+    included."""
+    _, out = _run_convert(tmp_path, monkeypatch, {"01_tensor": "dir_with_src"})
+    assert "01_tensor" in out
+    assert "Converting 1 module" in out
+
+
+def test_dotfile_directory_is_excluded_from_all(tmp_path, monkeypatch):
+    """is_dir() True, name starts with "." -> excluded. Paired with the
+    baseline: only the leading-dot name differs, isolating that half of
+    the and."""
+    _, out = _run_convert(
+        tmp_path,
+        monkeypatch,
+        {"01_tensor": "dir_with_src", ".hidden": "dir_with_src"},
+    )
+    assert "Converting 1 module" in out
+
+
+def test_underscore_prefixed_directory_is_excluded_from_all(tmp_path, monkeypatch):
+    """is_dir() True, name starts with "_" -> excluded. Paired with the
+    baseline: only the leading-underscore name differs, isolating that
+    half of the and (distinct atom from the dot-prefix test, since
+    startswith((".", "_")) is itself a 2-way check inside the not)."""
+    _, out = _run_convert(
+        tmp_path,
+        monkeypatch,
+        {"01_tensor": "dir_with_src", "__pycache__": "dir_with_src"},
+    )
+    assert "Converting 1 module" in out
+
+
+def test_plain_file_is_excluded_from_all(tmp_path, monkeypatch):
+    """is_dir() False (a regular file) -> excluded regardless of name.
+    Paired with the baseline: only is_dir()'s result differs, isolating
+    that half of the and."""
+    _, out = _run_convert(
+        tmp_path,
+        monkeypatch,
+        {"01_tensor": "dir_with_src", "readme.txt": "file"},
+    )
+    assert "Converting 1 module" in out
+
+
+# ---------------------------------------------------------------------------
+# specific-module OR: d.is_dir() and (name == module or
+#                                      name.startswith(f"{module}_") or
+#                                      name.endswith(f"_{module}"))
+# ---------------------------------------------------------------------------
+
+
+def test_exact_name_match_is_found(tmp_path, monkeypatch):
+    """Baseline: is_dir() True, name == args.module -> found."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"tensor": "dir_with_src"}, module="tensor")
+    assert result == 0
+    assert "Module not found" not in out
+
+
+def test_prefix_match_is_found(tmp_path, monkeypatch):
+    """name == module False, name.startswith(f"{module}_") True ->
+    found. Paired with the baseline: only which disjunct matches
+    differs, isolating this atom."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"01_tensor": "dir_with_src"}, module="01")
+    assert result == 0
+    assert "Module not found" not in out
+
+
+def test_suffix_match_is_found(tmp_path, monkeypatch):
+    """Neither exact nor prefix match, name.endswith(f"_{module}") True
+    -> found. Isolates the third disjunct."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"foo_tensor": "dir_with_src"}, module="tensor")
+    assert result == 0
+    assert "Module not found" not in out
+
+
+def test_no_match_reports_module_not_found(tmp_path, monkeypatch):
+    """All three disjuncts False -> not found, run() returns 1. Paired
+    with the exact-match baseline: only the module name's relation to
+    the directory name differs."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"01_tensor": "dir_with_src"}, module="unrelated")
+    assert result == 1
+    assert "Module not found: unrelated" in out
+
+
+def test_file_named_exactly_like_module_is_not_found(tmp_path, monkeypatch):
+    """is_dir() False, even with an exact name match -> not found.
+    Paired with the exact-match baseline: only is_dir()'s result
+    differs, isolating that half of the outer and."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"tensor": "file"}, module="tensor")
+    assert result == 1
+    assert "Module not found: tensor" in out
+
+
+def test_first_match_wins_and_stops_searching(tmp_path, monkeypatch):
+    """The specific-module loop breaks on the first match; a module
+    lacking a source file simply produces zero converted artifacts
+    rather than falling through to a later, unrelated matching dir."""
+    result, out = _run_convert(tmp_path, monkeypatch, {"01_tensor": "dir_no_src"}, module="01")
+    assert result == 0
+    assert "Converting 1 module" in out
+    assert "Successfully generated 0 artifact" in out

--- a/platforms/cli/tests/test_dev_test_build_package_streaming.py
+++ b/platforms/cli/tests/test_dev_test_build_package_streaming.py
@@ -1,0 +1,54 @@
+"""
+MC/DC coverage for DevTestCommand._build_package's CI-mode streaming
+keyword filter:
+    if any(x in line for x in ["Converting", "Exported", "✅", "❌", "Module"]):
+
+A generator-expression any() over 5 literal keywords, each isolated
+individually the way test_runtime_ci_and_interactive_detection.py isolated
+_CI_ENV_VARS.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from platforms.cli.cli_platform.dev.test import DevTestCommand
+from platforms.cli.core.config import CLIConfig
+
+TRENTORCH_ROOT = Path(__file__).resolve().parents[3]
+
+_KEYWORDS = ["Converting", "Exported", "✅", "❌", "Module"]
+
+
+class _FakeProcess:
+    def __init__(self, lines, returncode=0):
+        self.stdout = iter(lines)
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def _build(monkeypatch, capsys, lines):
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _FakeProcess(lines))
+    cmd = DevTestCommand(CLIConfig.from_project_root(TRENTORCH_ROOT))
+    cmd._build_package(TRENTORCH_ROOT, verbose=False, ci_mode=True)
+    return capsys.readouterr().out
+
+
+def test_line_with_none_of_the_five_keywords_is_not_printed(monkeypatch, capsys):
+    """Baseline: none of the 5 keywords present -> line filtered out."""
+    out = _build(monkeypatch, capsys, ["some unrelated debug line"])
+    assert "some unrelated debug line" not in out
+
+
+@pytest.mark.parametrize("keyword", _KEYWORDS)
+def test_each_keyword_alone_is_sufficient_to_print_the_line(monkeypatch, capsys, keyword):
+    """Each of the five keywords, present alone in an otherwise
+    unrelated line, independently makes the any() True -> line printed.
+    Paired with the baseline: only this one keyword's presence differs,
+    isolating it from the other four atoms in the any()."""
+    line = f"prefix {keyword} suffix"
+    out = _build(monkeypatch, capsys, [line])
+    assert line in out

--- a/platforms/cli/tests/test_export_module_verification.py
+++ b/platforms/cli/tests/test_export_module_verification.py
@@ -1,0 +1,85 @@
+"""
+MC/DC coverage for ModuleWorkflowCommand.export_module's export-verification
+code-line filter:
+    code_lines = [line for line in content.split("\n")
+                  if line.strip() and not line.strip().startswith("#")]
+
+Two atoms per line: "line.strip()" (non-blank) and
+"not line.strip().startswith('#')" (not a comment).
+"""
+
+from io import StringIO
+
+from rich.console import Console
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+
+def _export(tmp_path, monkeypatch, *, exported_content: str):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TREN_DEV_VERIFY_SOLUTION", raising=False)
+
+    module_dir = tmp_path / "data" / "modules" / "01_tensor"
+    module_dir.mkdir(parents=True)
+    (module_dir / "tensor.ipynb").write_text("{}", encoding="utf-8")
+
+    import platforms.cli.commands.export_utils as export_utils_module
+
+    monkeypatch.setattr(export_utils_module, "get_export_target", lambda path: "core.tensor")
+    monkeypatch.setattr(export_utils_module, "ensure_writable_target", lambda target: None)
+
+    lib_dir = tmp_path / "data" / "trentorch" / "core"
+    lib_dir.mkdir(parents=True)
+    target_file = lib_dir / "tensor.py"
+
+    import nbdev.export as nbdev_export_module
+
+    def fake_nb_export(notebook_path, lib_path):
+        target_file.write_text(exported_content, encoding="utf-8")
+
+    monkeypatch.setattr(nbdev_export_module, "nb_export", fake_nb_export)
+
+    cmd = ModuleWorkflowCommand(CLIConfig.from_project_root(tmp_path))
+    buf = StringIO()
+    cmd.console = Console(file=buf, width=200, no_color=True)
+    result = cmd.export_module("01_tensor")
+    return result, buf.getvalue()
+
+
+def test_exported_file_with_real_code_lines_passes_verification(tmp_path, monkeypatch):
+    """Baseline: multiple non-blank, non-comment lines -> passes (>= 2
+    code_lines required)."""
+    result, out = _export(tmp_path, monkeypatch, exported_content="x = 1\ny = 2\n")
+    assert result == 0
+    assert "verification failed" not in out
+
+
+def test_blank_lines_are_not_counted_as_code(tmp_path, monkeypatch):
+    """line.strip() False (blank line) -> excluded even though it's not
+    a comment. Paired with the baseline: an exported file made entirely
+    of blank lines has zero code_lines, isolating the blank-line half of
+    the and."""
+    result, out = _export(tmp_path, monkeypatch, exported_content="\n\n\n")
+    assert result == 1
+    assert "verification failed" in out
+
+
+def test_comment_only_lines_are_not_counted_as_code(tmp_path, monkeypatch):
+    """line.strip() True, "not line.strip().startswith('#')" False (a
+    comment) -> excluded. Paired with the baseline: an exported file
+    made entirely of non-blank comment lines has zero code_lines,
+    isolating the comment half of the and."""
+    result, out = _export(tmp_path, monkeypatch, exported_content="# comment one\n# comment two\n")
+    assert result == 1
+    assert "verification failed" in out
+
+
+def test_mix_of_one_real_line_and_comments_falls_short_of_threshold(tmp_path, monkeypatch):
+    """Exactly one real code line (plus comments/blanks, all filtered
+    out) -> code_lines has length 1, below the "< 2" threshold ->
+    still fails. Confirms comment and blank lines are excluded
+    independently, not just when one of them is the only content."""
+    result, out = _export(tmp_path, monkeypatch, exported_content="# header\n\nx = 1\n")
+    assert result == 1
+    assert "verification failed" in out

--- a/platforms/cli/tests/test_milestone_info_prereqs_met.py
+++ b/platforms/cli/tests/test_milestone_info_prereqs_met.py
@@ -1,0 +1,77 @@
+"""
+MC/DC coverage for milestone/display.py's show_info copy of the
+prereqs_met all() -- the same shape already covered for show_list's copy
+in test_milestone_list_run_now_text.py. Uses two required modules so
+each module's completion independently matters (a single-element list
+would make the all() trivially reduce to one check).
+"""
+
+import json
+from io import StringIO
+
+from rich.console import Console
+
+import platforms.cli.processes.milestone.display as display_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.milestone.display import show_info
+
+
+def _milestone(required_modules):
+    return {
+        "id": "1",
+        "name": "Test",
+        "emoji": "🎯",
+        "title": "Test",
+        "description": "Test",
+        "historical_context": "None",
+        "year": 1958,
+        "required_modules": required_modules,
+        "script": "test.py",
+    }
+
+
+def _show_info(tmp_path, monkeypatch, *, completed_modules, required_modules):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "user_data").mkdir(exist_ok=True)
+    (tmp_path / "user_data" / "progress.json").write_text(
+        json.dumps({"completed_modules": completed_modules}), encoding="utf-8"
+    )
+    monkeypatch.setattr(display_module, "MILESTONE_SCRIPTS", {"1": _milestone(required_modules)})
+
+    from argparse import Namespace
+
+    config = CLIConfig.from_project_root(tmp_path)
+    buf = StringIO()
+    console = Console(file=buf, width=120, no_color=True)
+    show_info(config, console, Namespace(milestone_id="1"))
+    return buf.getvalue()
+
+
+def test_both_required_modules_completed_shows_ready_to_run(tmp_path, monkeypatch):
+    """Baseline: both required modules completed -> prereqs_met True ->
+    "Ready to run!" shown."""
+    out = _show_info(tmp_path, monkeypatch, completed_modules=["01", "02"], required_modules=[1, 2])
+    assert "Ready to run!" in out
+    assert "Locked" not in out
+
+
+def test_only_first_required_module_completed_shows_locked(tmp_path, monkeypatch):
+    """Only module 1 of [1, 2] completed -> all() False -> "Locked"
+    shown, module 2 listed as still needed. Paired with the baseline:
+    only module 2's completion differs, isolating its independent
+    effect on the all()."""
+    out = _show_info(tmp_path, monkeypatch, completed_modules=["01"], required_modules=[1, 2])
+    assert "Locked" in out
+    assert "Ready to run!" not in out
+    assert "Complete modules: 02" in out
+
+
+def test_only_second_required_module_completed_shows_locked(tmp_path, monkeypatch):
+    """Only module 2 of [1, 2] completed -> all() False -> "Locked"
+    shown, module 1 listed as still needed. Paired with the baseline:
+    only module 1's completion differs, isolating its independent
+    effect, distinct from the previous test's isolation of module 1."""
+    out = _show_info(tmp_path, monkeypatch, completed_modules=["02"], required_modules=[1, 2])
+    assert "Locked" in out
+    assert "Ready to run!" not in out
+    assert "Complete modules: 01" in out

--- a/platforms/cli/tests/test_milestone_readiness_check.py
+++ b/platforms/cli/tests/test_milestone_readiness_check.py
@@ -1,0 +1,78 @@
+"""
+MC/DC coverage for ModuleWorkflowCommand._check_milestone_readiness's
+readiness decision: all_modules_done = all(m in completed_set for m in required),
+tested with two required modules so each independently matters (a single-
+element required list would make the all() trivially reduce to one check).
+"""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+import platforms.cli.processes.milestone as milestone_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+
+@pytest.fixture
+def workflow(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "user_data").mkdir(exist_ok=True)
+    cmd = ModuleWorkflowCommand(CLIConfig.from_project_root(tmp_path))
+    cmd.console = Console(file=StringIO(), width=200, no_color=True)
+    return cmd
+
+
+def _milestone():
+    return {"name": "Test Milestone", "required_modules": [1, 2]}
+
+
+def _readiness(workflow, monkeypatch, completed_modules):
+    monkeypatch.setattr(milestone_module, "MILESTONE_SCRIPTS", {"1": _milestone()})
+    return workflow._check_milestone_readiness(completed_modules)
+
+
+def test_both_required_modules_completed_marks_ready(workflow, monkeypatch):
+    """Baseline: both required modules (1 and 2) completed -> all() True
+    -> milestone marked "ready"."""
+    result = _readiness(workflow, monkeypatch, ["01", "02"])
+    assert ("1", "Test Milestone", "ready") in result
+
+
+def test_only_first_required_module_completed_is_not_ready(workflow, monkeypatch):
+    """Only module 1 of [1, 2] completed -> all() False -> milestone not
+    in the result at all (neither "ready" nor "unlocked"). Paired with
+    the baseline: only module 2's completion differs, isolating its
+    independent effect on the all()."""
+    result = _readiness(workflow, monkeypatch, ["01"])
+    assert not any(mid == "1" for mid, _, _ in result)
+
+
+def test_only_second_required_module_completed_is_not_ready(workflow, monkeypatch):
+    """Only module 2 of [1, 2] completed -> all() False. Paired with the
+    baseline: only module 1's completion differs, isolating its
+    independent effect, distinct from the previous test's isolation of
+    module 1."""
+    result = _readiness(workflow, monkeypatch, ["02"])
+    assert not any(mid == "1" for mid, _, _ in result)
+
+
+def test_neither_required_module_completed_is_not_ready(workflow, monkeypatch):
+    """Neither required module completed -> all() False, same outcome as
+    the single-module-missing cases but confirms the all() doesn't
+    require exactly one missing item to short-circuit correctly."""
+    result = _readiness(workflow, monkeypatch, [])
+    assert not any(mid == "1" for mid, _, _ in result)
+
+
+def test_already_completed_milestone_reports_unlocked_not_ready(workflow, monkeypatch):
+    """A milestone already in completed_milestones.json is reported as
+    "unlocked" regardless of all_modules_done, since that branch is
+    checked first (elif all_modules_done is only reached when the
+    milestone isn't already completed)."""
+    milestones_file = workflow.config.project_root / "user_data" / "milestones.json"
+    milestones_file.write_text('{"completed_milestones": ["1"]}', encoding="utf-8")
+
+    result = _readiness(workflow, monkeypatch, ["01", "02"])
+    assert ("1", "Test Milestone", "unlocked") in result

--- a/platforms/cli/tests/test_module_test_result_fallback.py
+++ b/platforms/cli/tests/test_module_test_result_fallback.py
@@ -1,0 +1,102 @@
+"""
+MC/DC coverage for ModuleTestCommand's two independent copies of the same
+result.stderr or result.stdout fallback: run_module_pytest (line ~179) and
+run_integration_tests (line ~283). Textually identical, but distinct
+methods with distinct setup, so each gets its own isolation pair.
+"""
+
+import subprocess
+from io import StringIO
+from types import SimpleNamespace
+
+from rich.console import Console
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.module_workflow.test import ModuleTestCommand
+
+
+def _fake_result(*, returncode, stdout, stderr):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _command(tmp_path):
+    cmd = ModuleTestCommand(CLIConfig.from_project_root(tmp_path))
+    cmd.console = Console(file=StringIO(), width=200, no_color=True)
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# run_module_pytest: on failure, return result.stderr or result.stdout
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_failure_with_stderr_returns_stderr(tmp_path, monkeypatch):
+    """Baseline: returncode != 0, result.stderr truthy -> stderr
+    returned (the or's left side wins)."""
+    tests_dir = tmp_path / "data" / "src" / "01_tensor" / "tests"
+    tests_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _fake_result(returncode=1, stdout="stdout text", stderr="stderr text"),
+    )
+    cmd = _command(tmp_path)
+    ok, message = cmd.run_module_pytest("01_tensor", "01")
+    assert ok is False
+    assert message == "stderr text"
+
+
+def test_pytest_failure_with_empty_stderr_falls_back_to_stdout(tmp_path, monkeypatch):
+    """result.stderr falsy (empty string) -> falls back to result.stdout.
+    Paired with the baseline: only stderr's truthiness differs,
+    isolating that half of the or."""
+    tests_dir = tmp_path / "data" / "src" / "01_tensor" / "tests"
+    tests_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _fake_result(returncode=1, stdout="stdout text", stderr="")
+    )
+    cmd = _command(tmp_path)
+    ok, message = cmd.run_module_pytest("01_tensor", "01")
+    assert ok is False
+    assert message == "stdout text"
+
+
+# ---------------------------------------------------------------------------
+# run_integration_tests: same fallback pattern, distinct method
+# ---------------------------------------------------------------------------
+
+
+def _setup_integration(tmp_path):
+    integration_dir = tmp_path / "tests" / "integration"
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "test_layers_integration.py").write_text("", encoding="utf-8")
+
+
+def test_integration_failure_with_stderr_returns_stderr(tmp_path, monkeypatch):
+    """Baseline: returncode != 0, result.stderr truthy -> stderr
+    returned. A distinct method from run_module_pytest, exercising the
+    same or shape independently."""
+    _setup_integration(tmp_path)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _fake_result(returncode=1, stdout="stdout text", stderr="stderr text"),
+    )
+    cmd = _command(tmp_path)
+    ok, message = cmd.run_integration_tests("03")
+    assert ok is False
+    assert message == "stderr text"
+
+
+def test_integration_failure_with_empty_stderr_falls_back_to_stdout(tmp_path, monkeypatch):
+    """result.stderr falsy -> falls back to result.stdout. Paired with
+    the baseline: only stderr's truthiness differs, isolating that half
+    of the or, distinct from run_module_pytest's own isolation pair."""
+    _setup_integration(tmp_path)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _fake_result(returncode=1, stdout="stdout text", stderr="")
+    )
+    cmd = _command(tmp_path)
+    ok, message = cmd.run_integration_tests("03")
+    assert ok is False
+    assert message == "stdout text"

--- a/platforms/cli/tests/test_start_module_milestone_countdown.py
+++ b/platforms/cli/tests/test_start_module_milestone_countdown.py
@@ -1,0 +1,84 @@
+"""
+MC/DC coverage for ModuleWorkflowCommand.start_module's "modules until
+unlock" computation:
+    modules_left = len([r for r in required if r not in completed_nums])
+
+This started as a 2-atom "r not in completed_nums and r >= module_num".
+Writing the independent-isolation test for "r >= module_num" showed it's
+dead: the prerequisite check a few lines above already returns 1 if any
+module before module_num is incomplete, so any required r < module_num is
+guaranteed already in completed_nums by the time this line runs. Fixed by
+dropping the redundant half rather than testing an unreachable branch.
+"""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+import platforms.cli.processes.module_workflow.workflow as workflow_module
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+
+@pytest.fixture
+def workflow(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cmd = ModuleWorkflowCommand(CLIConfig.from_project_root(tmp_path))
+    cmd.console = Console(file=StringIO(), width=200, no_color=True)
+    return cmd
+
+
+def _start(workflow, monkeypatch, *, module_mapping, completed, required, module_num):
+    monkeypatch.setattr(workflow_module, "get_module_mapping", lambda: module_mapping)
+    monkeypatch.setattr(
+        workflow_module.ModuleWorkflowCommand,
+        "_get_milestone_for_module",
+        lambda self, num: ("1", "Test Milestone", required),
+    )
+    workflow.save_progress_data({"completed_modules": completed, "started_modules": []})
+
+    normalized = f"{module_num:02d}"
+    module_name = module_mapping[normalized]
+    module_dir = workflow.config.project_root / "data" / "modules" / module_name
+    module_dir.mkdir(parents=True)
+    short_name = module_name.split("_", 1)[1]
+    (module_dir / f"{short_name}.ipynb").write_text("{}", encoding="utf-8")
+
+    buf = StringIO()
+    workflow.console = Console(file=buf, width=200, no_color=True)
+    workflow.start_module(normalized, no_jupyter=True)
+    return buf.getvalue()
+
+
+def _mapping(up_to: int) -> dict:
+    return {f"{i:02d}": f"{i:02d}_module{i}" for i in range(1, up_to + 1)}
+
+
+def test_uncompleted_required_module_counts_toward_countdown(workflow, monkeypatch):
+    """Baseline: for required module r, r not in completed_nums True ->
+    counted, shown since modules_left <= 3. (required must include
+    module_num itself: the milestone row only prints when
+    "module_num in required" is True.)"""
+    out = _start(workflow, monkeypatch, module_mapping=_mapping(3), completed=[], required=[1], module_num=1)
+    assert "1 modules until unlock" in out
+
+
+def test_completed_required_module_does_not_count(workflow, monkeypatch):
+    """r not in completed_nums False (it's already completed) -> not
+    counted. Paired with the baseline: only whether r is in
+    completed_nums differs, isolating that half of the and."""
+    out = _start(
+        workflow, monkeypatch, module_mapping=_mapping(3), completed=["01"], required=[1], module_num=1
+    )
+    assert "0 modules until unlock" in out
+
+
+def test_multiple_uncompleted_required_modules_all_count(workflow, monkeypatch):
+    """Two required modules, neither completed -> both counted
+    independently (confirms the filter isn't just checking "any", it
+    genuinely counts each element)."""
+    out = _start(
+        workflow, monkeypatch, module_mapping=_mapping(3), completed=[], required=[1, 2], module_num=1
+    )
+    assert "2 modules until unlock" in out


### PR DESCRIPTION
Final batch of the MC/DC testing pass on platforms/cli/: covers the 8 remaining known gaps, surveyed and executed together instead of one PR per fix.

## What's covered

- **convert.py**: ConvertCommand.run's module-discovery filter (`is_dir() and not startswith((".", "_"))`) and the specific-module 4-atom OR (exact/prefix/suffix name match)
- **workflow.py**:
  - export_module's export-verification code-line filter (`line.strip() and not line.strip().startswith("#")`)
  - _check_milestone_readiness's `all(m in completed_set for m in required)`, tested with two required modules so each independently matters
  - start_module's milestone countdown -- found a real dead condition here: `r >= module_num` can never be false when it matters, since the prerequisite check a few lines above already guarantees every module before `module_num` is completed by the time this code runs. Simplified to drop the redundant half rather than write a test for an unreachable branch.
- **module_workflow/test.py**: the two independent `result.stderr or result.stdout` fallback copies in `run_module_pytest` and `run_integration_tests`
- **milestone/display.py**: show_info's `prereqs_met` all(), given the same multi-required-module fix already applied to show_list's copy in an earlier PR

## Verification

- 408 local tests pass (`pytest platforms/cli/tests/`)
- `ruff check` and `ruff format --check` both clean