### PR TITLE
Close main.py's own Windows-detection MC/DC gap

### DIFF
--- a/platforms/cli/main.py
+++ b/platforms/cli/main.py
@@ -19,7 +19,22 @@ from pathlib import Path
 # not UTF-8, so emoji output crashes with UnicodeEncodeError unless the
 # already-open streams are reconfigured directly (setting PYTHONIOENCODING
 # here is too late to affect them).
-if sys.platform == "win32" or os.name == "nt":
+
+
+def _is_windows(platform: str, os_name: str) -> bool:
+    """Whether stdout/stderr need UTF-8 reconfiguration for this platform.
+
+    Pulled out of the top-level if so it's callable directly with fake
+    platform/os_name values in a test -- the original inline check could
+    only be exercised by reloading this whole module under a monkeypatched
+    sys.platform/os.name, which cascades into re-running every import below
+    (including export_utils.py's module-level Path(...) default argument)
+    and crashes on a real Windows filesystem.
+    """
+    return platform == "win32" or os_name == "nt"
+
+
+if _is_windows(sys.platform, os.name):
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
     for _stream in (sys.stdout, sys.stderr):
         if hasattr(_stream, "reconfigure"):

--- a/platforms/cli/tests/test_main_windows_stdio_detection.py
+++ b/platforms/cli/tests/test_main_windows_stdio_detection.py
@@ -1,0 +1,34 @@
+"""
+MC/DC coverage for main.py's own copy of the Windows-detection decision:
+_is_windows(platform, os_name) = platform == "win32" or os_name == "nt".
+
+This decision used to be inline (`if sys.platform == "win32" or os.name ==
+"nt":`), directly at module import time, which meant the only way to test
+it independently of the real host platform was to reload platforms.cli.main
+under a monkeypatched sys.platform/os.name -- but that reload re-runs every
+import below it, including export_utils.py's module-level Path(...) default
+argument, which crashes instantiating the wrong Path flavor on a real
+Windows filesystem. Pulling the decision out into its own function makes it
+callable directly with fake inputs, with no reload and no crash risk.
+"""
+
+from platforms.cli.main import _is_windows
+
+
+def test_win32_platform_alone_is_windows():
+    """Baseline: platform == "win32" True, os_name == "nt" False ->
+    Windows."""
+    assert _is_windows("win32", "posix") is True
+
+
+def test_nt_os_name_alone_is_windows():
+    """platform == "win32" False, os_name == "nt" True -> Windows.
+    Paired with the baseline: only os_name differs, isolating that half
+    of the or."""
+    assert _is_windows("linux", "nt") is True
+
+
+def test_neither_signal_is_not_windows():
+    """Both False -> not Windows. Paired with the baseline: only
+    platform's value differs, isolating that half of the or."""
+    assert _is_windows("linux", "posix") is False


### PR DESCRIPTION
Closes the last documented MC/DC gap in platforms/cli/: main.py's own copy of the Windows-detection decision (`sys.platform == "win32" or os.name == "nt"`), previously deferred as unsafe to test.

## Why it was deferred

The decision lives directly in a top-level `if` at import time. The only way to exercise it independently of the real host platform was reloading `platforms.cli.main` under a monkeypatched `sys.platform`/`os.name` -- but that reload re-runs every import below it, including `export_utils.py`'s module-level `Path(...)` default argument, which crashes instantiating the wrong `Path` flavor on a real Windows filesystem.

## Fix

Extracted the condition into `_is_windows(platform: str, os_name: str) -> bool`, called once at the same import-time spot with the real `sys.platform`/`os.name`. Behavior is unchanged -- same condition, same actions (UTF-8 stdout/stderr reconfiguration), still run once at import. The function is now callable directly with fake inputs in a test, no reload, no crash risk.

## Verification

- New test isolates both atoms of the `or` directly against `_is_windows`
- `python -c "from platforms.cli.main import main"` and `tren --help` both still work, confirming the real reconfiguration still runs and emoji still render correctly
- 420 local tests pass (`pytest platforms/cli/tests/`)
- `ruff check` and `ruff format --check` both clean