### PR TITLE
Add community health files for the org move

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default reviewers for anything not matched below.
+# Branch protection doesn't currently require CODEOWNERS approval (0
+# required approving reviews on main), so this only drives automatic
+# review requests, not a merge block.
+* @Shashank-Tripathi-07 @ShivtejG236

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something in the CLI, a module, or the curriculum isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact `tren` commands (or notebook cells) that trigger it
+      placeholder: |
+        1. tren module start 05
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: Paste the error message or terminal output. This will be auto-formatted as code.
+      render: shell
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "Windows 11 / Ubuntu 22.04 / macOS 14 (Apple Silicon)"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: TrenTorch / Python version
+      placeholder: "Output of `tren --version` and `python --version`"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/TrenTorch/TrenTorch/security
+    about: Please report security issues through the private advisory flow, not a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a module, CLI feature, or curriculum improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the gap?
+      description: What can't you currently do, or what's confusing/missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you want to see instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about, and why they didn't fit

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What does this PR do?
+
+<!-- One or two sentences: what changed and why. -->
+
+## How was this tested?
+
+<!-- Commands you ran, tests you added, or "CI covers this" if the existing suite is enough. -->
+
+## Checklist
+
+- [ ] `ruff check` and `ruff format --check` pass locally
+- [ ] Relevant tests pass locally (`pytest platforms/cli/tests/` for CLI changes)
+- [ ] This doesn't touch `data/src/` unless the change is actually about the curriculum content itself

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want TrenTorch to be a welcoming place to learn ML systems engineering, regardless of experience level, background, or how new you are to open source. We pledge to make participation in this project a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experience levels
+- Giving and gracefully accepting constructive feedback on code and ideas
+- Focusing on what's best for the project and the people learning from it
+- Showing patience with people new to ML, systems programming, or open source itself
+
+Examples of unacceptable behavior:
+
+- Harassment, insulting or derogatory comments, and personal or political attacks
+- Publishing others' private information without explicit permission
+- Trolling, deliberately disruptive comments, or sustained disruption of discussion
+- Any conduct which could reasonably be considered inappropriate in a professional or educational setting
+
+## Scope
+
+This applies within all project spaces (issues, pull requests, discussions, the wiki) and in any space where someone is representing the project or its community.
+
+## Enforcement
+
+Instances of unacceptable behavior can be reported by opening a [private security advisory](https://github.com/TrenTorch/TrenTorch/security) (the same private-reporting flow used for security issues, appropriate here too since it's not public) or by contacting a maintainer directly. All complaints will be reviewed and investigated promptly and fairly.
+
+Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
Fills out GitHub's community profile checklist, currently at 62% (missing code_of_conduct, issue_template, pull_request_template).

- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.1, adapted. Enforcement contact routes through the same private security-advisory flow SECURITY.md already documents, rather than publishing anyone's email.
- **.github/ISSUE_TEMPLATE/**: bug report and feature request forms, plus a `config.yml` that points security reports at SECURITY.md instead of a public issue.
- **.github/PULL_REQUEST_TEMPLATE.md**: what/how/checklist, matching what CONTRIBUTING.md already asks contributors to do.
- **.github/CODEOWNERS**: default reviewers only. Branch protection doesn't require CODEOWNERS approval (0 required approving reviews on main), so this drives auto-review-requests, not a merge gate.