### PR TITLE
Fuzz-testing survey: fix network-reachable server crash + isdigit()/int() crash

### DIFF
--- a/platforms/cli/core/modules.py
+++ b/platforms/cli/core/modules.py
@@ -117,12 +117,23 @@ def normalize_module_number(module_input: str) -> str:
     """
     # If it's a pure number
     if module_input.isdigit():
-        return f"{int(module_input):02d}"
+        # str.isdigit() accepts Unicode digit characters (superscripts,
+        # Devanagari/Tamil/etc. numerals) that int() can't parse -- e.g.
+        # "²" (superscript two) isdigit()s True but int() raises
+        # ValueError. Fall through and treat it as a non-numeric input
+        # instead of crashing.
+        try:
+            return f"{int(module_input):02d}"
+        except ValueError:
+            return module_input
     # If it's a folder name like "15_quantization", extract the number
     if "_" in module_input:
         prefix = module_input.split("_")[0]
         if prefix.isdigit():
-            return f"{int(prefix):02d}"
+            try:
+                return f"{int(prefix):02d}"
+            except ValueError:
+                return module_input
     return module_input
 
 

--- a/platforms/cli/processes/module_workflow/workflow.py
+++ b/platforms/cli/processes/module_workflow/workflow.py
@@ -306,10 +306,16 @@ class ModuleWorkflowCommand(BaseCommand):
         if milestone_info:
             mid, mname, required = milestone_info
             if module_num in required:
+                # Reuses the already-fuzz-safe helper rather than a raw
+                # isdigit()+int() pair: str.isdigit() accepts Unicode digit
+                # characters (e.g. superscripts) that int() then raises
+                # ValueError on. completed_modules comes straight from
+                # progress.json, which isn't schema-validated, so a
+                # crafted/corrupted entry there could otherwise crash here.
+                from platforms.cli.processes.milestone import _module_progress_to_int
+
                 completed_nums = {
-                    int(str(module).split("_", 1)[0])
-                    for module in completed
-                    if str(module).split("_", 1)[0].isdigit()
+                    n for n in (_module_progress_to_int(module) for module in completed) if n is not None
                 }
                 # r >= module_num is always true here: the prerequisite
                 # check above already returned 1 if any module before

--- a/platforms/cli/server/handler.py
+++ b/platforms/cli/server/handler.py
@@ -71,6 +71,21 @@ class TrenTorchRequestHandler(SimpleHTTPRequestHandler):
     def _trusted_hostnames(self) -> set[str]:
         return LOOPBACK_HOSTS | {h.lower() for h in self.allowed_hosts}
 
+    @staticmethod
+    def _safe_hostname(url: str) -> str:
+        """urlparse(...).hostname, but never raises.
+
+        Found by fuzzing: urlparse() raises ValueError on a malformed IPv6
+        host (e.g. "http://[::1" -- an unclosed bracket), and both callers
+        below feed it directly from the request's own Origin header with no
+        try/except, which is real network-reachable input, not something a
+        client is trusted to format correctly.
+        """
+        try:
+            return urlparse(url).hostname or ""
+        except ValueError:
+            return ""
+
     def _request_is_local(self) -> bool:
         """True only for same-machine requests that no remote page can forge.
 
@@ -85,7 +100,7 @@ class TrenTorchRequestHandler(SimpleHTTPRequestHandler):
 
         origin = self.headers.get("Origin")
         if origin:
-            origin_host = urlparse(origin).hostname or ""
+            origin_host = self._safe_hostname(origin)
             if origin_host.lower() not in trusted:
                 return False
 
@@ -100,7 +115,7 @@ class TrenTorchRequestHandler(SimpleHTTPRequestHandler):
     def do_OPTIONS(self):
         """Handle CORS pre-flight requests (loopback origins only)."""
         origin = self.headers.get("Origin", "")
-        origin_host = (urlparse(origin).hostname or "").lower()
+        origin_host = self._safe_hostname(origin).lower()
         self.send_response(HTTPStatus.OK)
         if origin and origin_host in self._trusted_hostnames():
             self.send_header("Access-Control-Allow-Origin", origin)
@@ -111,7 +126,15 @@ class TrenTorchRequestHandler(SimpleHTTPRequestHandler):
 
     def do_GET(self):
         """Handle GET requests for API endpoints and static assets."""
-        parsed = urlparse(self.path)
+        # self.path is the raw request target -- attacker-controlled, same
+        # as the Origin header above. urlparse() raises ValueError on a
+        # malformed IPv6-looking authority (e.g. a request line of
+        # "GET //[::1/x HTTP/1.1"), which a real HTTP client can send.
+        try:
+            parsed = urlparse(self.path)
+        except ValueError:
+            self._send_json({"error": "Malformed request path"}, status=HTTPStatus.BAD_REQUEST)
+            return
         path = parsed.path.rstrip("/")
 
         if path == "/api/status":
@@ -137,7 +160,11 @@ class TrenTorchRequestHandler(SimpleHTTPRequestHandler):
 
     def do_POST(self):
         """Handle POST requests for actions."""
-        parsed = urlparse(self.path)
+        try:
+            parsed = urlparse(self.path)
+        except ValueError:
+            self._send_json({"error": "Malformed request path"}, status=HTTPStatus.BAD_REQUEST)
+            return
         path = parsed.path.rstrip("/")
 
         if path.startswith("/api/modules/") and path.endswith("/complete"):

--- a/platforms/cli/tests/test_fuzz_number_parsing.py
+++ b/platforms/cli/tests/test_fuzz_number_parsing.py
@@ -1,0 +1,88 @@
+"""
+Hypothesis-based fuzz coverage for the codebase's number-parsing entry
+points -- functions that take a raw string (a CLI arg, or content read back
+from progress.json) and try to turn it into an int.
+
+Found via survey: `str.isdigit()` returns True for 128 distinct Unicode
+code points (superscripts like "²", Devanagari/Tamil/etc. numerals,
+circled digits, ...) that `int()` then rejects with ValueError -- so the
+common `if s.isdigit(): int(s)` pattern is not actually safe against
+arbitrary text, only against ASCII digits. Both bugs here were found by
+this fuzz pass, not assumed in advance.
+"""
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from platforms.cli.core.modules import normalize_module_number
+from platforms.cli.processes.milestone import _module_progress_to_int
+
+# A curated sample of the 128 "isdigit() True, int() raises" code points
+# (superscript/subscript digits and Ethiopic digits, verified individually
+# against int() -- not every isdigit()-True character behaves this way;
+# e.g. Tibetan digit one (U+0F21) is a real decimal digit int() accepts
+# fine, so it's deliberately not in this list), used as concrete
+# regression examples alongside the broader random-text fuzzing below.
+ISDIGIT_BUT_NOT_INT_PARSEABLE = ["²", "³", "⁹", "₀", "፩", "፰"]
+
+
+# ---------------------------------------------------------------------------
+# normalize_module_number: must never raise, for any string input
+# ---------------------------------------------------------------------------
+
+
+@given(st.text())
+@example("²")  # superscript two -- the original crash this fixes
+@example("²_module")
+def test_normalize_module_number_never_raises(module_input):
+    """No string input should crash this -- worst case, an unrecognized
+    input is returned unchanged (the function's own documented fallback
+    for non-numeric input), never an uncaught exception."""
+    result = normalize_module_number(module_input)
+    assert isinstance(result, str)
+
+
+def test_normalize_module_number_handles_isdigit_but_unparseable_chars():
+    """Concrete regression check for the specific bug class: each of
+    these isdigit()s True but int() rejects. Before the fix, this raised
+    ValueError instead of falling back to the unrecognized-input path."""
+    for char in ISDIGIT_BUT_NOT_INT_PARSEABLE:
+        assert normalize_module_number(char) == char
+        assert normalize_module_number(f"{char}_tensor") == f"{char}_tensor"
+
+
+def test_normalize_module_number_still_normalizes_real_ascii_digits():
+    """The fix doesn't regress the actual documented behavior."""
+    assert normalize_module_number("1") == "01"
+    assert normalize_module_number("15") == "15"
+    assert normalize_module_number("15_quantization") == "15"
+
+
+# ---------------------------------------------------------------------------
+# _module_progress_to_int: must never raise, for any input shape
+# ---------------------------------------------------------------------------
+
+
+@given(st.one_of(st.text(), st.integers(), st.none(), st.floats(), st.booleans()))
+@example("²_tensor")
+def test_module_progress_to_int_never_raises(value):
+    """progress.json's completed_modules list isn't schema-validated, so
+    this needs to tolerate arbitrary JSON-decodable values, not just the
+    well-formed "01_tensor" strings it normally sees."""
+    result = _module_progress_to_int(value)
+    assert result is None or isinstance(result, int)
+
+
+def test_module_progress_to_int_handles_isdigit_but_unparseable_prefix():
+    """Same bug class as normalize_module_number, different function:
+    a module entry whose numeric-looking prefix isn't int()-parseable
+    should resolve to None (unrecognized), not raise."""
+    for char in ISDIGIT_BUT_NOT_INT_PARSEABLE:
+        assert _module_progress_to_int(f"{char}_tensor") is None
+
+
+def test_module_progress_to_int_still_parses_real_entries():
+    assert _module_progress_to_int("01_tensor") == 1
+    assert _module_progress_to_int("01") == 1
+    assert _module_progress_to_int(1) == 1
+    assert _module_progress_to_int("not_a_number") is None

--- a/platforms/cli/tests/test_fuzz_server_handler.py
+++ b/platforms/cli/tests/test_fuzz_server_handler.py
@@ -1,0 +1,138 @@
+"""
+Fuzz coverage for server/handler.py's URL/header parsing -- the highest-
+priority target from the fuzz-testing survey (issue #72), since the
+Origin header and the raw request path are genuine network-attacker-
+controlled input, not just a local CLI arg or a hand-edited progress.json.
+
+Found via fuzzing urlparse() directly (not assumed): it raises ValueError
+on a malformed IPv6-looking authority, e.g. "http://[::1" (unclosed
+bracket) or a request path starting "//[::1/x". Both _request_is_local
+(reads the Origin header) and do_GET/do_POST (read self.path, the raw
+request target) called urlparse() with no try/except, so either one was
+a real, remotely-triggerable crash of that request's handling thread.
+"""
+
+import http.client
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.server.handler import TrenTorchRequestHandler
+
+# ---------------------------------------------------------------------------
+# _safe_hostname: the core of the fix, tested directly (fast, no server)
+# ---------------------------------------------------------------------------
+
+
+@given(st.text())
+@settings(max_examples=300)
+def test_safe_hostname_never_raises(url):
+    result = TrenTorchRequestHandler._safe_hostname(url)
+    assert isinstance(result, str)
+
+
+def test_safe_hostname_handles_malformed_ipv6():
+    """The specific string that crashed urlparse() before the fix."""
+    assert TrenTorchRequestHandler._safe_hostname("http://[::1") == ""
+    assert TrenTorchRequestHandler._safe_hostname("http://[") == ""
+
+
+def test_safe_hostname_still_parses_real_origins():
+    assert TrenTorchRequestHandler._safe_hostname("http://localhost:8080") == "localhost"
+    assert TrenTorchRequestHandler._safe_hostname("http://127.0.0.1") == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a real HTTP request with a malformed Origin header, or a
+# malformed raw request path, must get a clean HTTP response -- not a
+# dropped/reset connection from an unhandled exception in the handler.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def running_server():
+    config = CLIConfig.from_project_root()
+    TrenTorchRequestHandler.config = config
+    TrenTorchRequestHandler.allowed_hosts = set()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), TrenTorchRequestHandler)
+    port = server.server_port
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield "127.0.0.1", port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_malformed_origin_header_gets_clean_response_not_a_crash(running_server):
+    """Before the fix: urlparse("http://[::1") inside _request_is_local
+    raised, uncaught, from inside do_GET -- this request would either hang,
+    reset, or 500 depending on socketserver's error handling, instead of
+    the clean 403 a normal untrusted-origin request gets."""
+    host, port = running_server
+    req = urllib.request.Request(f"http://{host}:{port}/api/status", headers={"Origin": "http://[::1"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    # Whatever the trust decision lands on, the server must respond at all
+    # (not reset the connection), and it must be a real HTTP status, not a
+    # 500 from an unhandled exception leaking out of the handler.
+    assert status in (200, 403)
+
+
+def test_malformed_request_path_gets_clean_400_not_a_dropped_connection(running_server):
+    """Sends a raw request line with an absolute-form request-target (the
+    form real clients use for proxied requests, e.g. "GET http://host/path
+    HTTP/1.1") whose "host" is a malformed IPv6 literal. urllib.request
+    itself would never construct this, so it goes through a raw socket.
+
+    A same-shaped "//[::1/x" origin-form target doesn't reach urlparse()
+    with the broken value at all: Python's own http.server collapses a
+    leading "//" to a single "/" before self.path is set (an open-redirect
+    hardening, unrelated to this bug) -- verified directly against this
+    interpreter before relying on it, since it's what makes the absolute-
+    form case the one that actually still reaches the crash."""
+    host, port = running_server
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    try:
+        conn.putrequest("GET", "http://[::1/x", skip_host=True, skip_accept_encoding=True)
+        conn.putheader("Host", f"{host}:{port}")
+        conn.endheaders()
+        response = conn.getresponse()
+        assert response.status == 400
+        body = json.loads(response.read().decode("utf-8"))
+        assert "error" in body
+    finally:
+        conn.close()
+
+
+def test_leading_double_slash_path_is_collapsed_before_reaching_us(running_server):
+    """Documents the http.server behavior the test above depends on: a
+    "//[::1/x" origin-form target never reaches our urlparse() call with
+    the un-collapsed value, so it can't reproduce the crash -- it's not
+    that our fix handles it, it's that the stdlib already does, one layer
+    up. If a future Python drops that hardening, this test starts failing
+    loudly instead of the coverage above silently testing the wrong thing."""
+    host, port = running_server
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    try:
+        conn.putrequest("GET", "//[::1/x", skip_host=True, skip_accept_encoding=True)
+        conn.putheader("Host", f"{host}:{port}")
+        conn.endheaders()
+        response = conn.getresponse()
+        # Collapsed to "/[::1/x" by http.server itself -> falls through to
+        # the static file server -> a plain 404, not our JSON 400.
+        assert response.status == 404
+    finally:
+        conn.close()

--- a/platforms/cli/tests/test_fuzz_text_parsers.py
+++ b/platforms/cli/tests/test_fuzz_text_parsers.py
@@ -1,0 +1,206 @@
+"""
+Hypothesis fuzz coverage for the codebase's other pure text-parsing
+functions, surveyed after test_fuzz_number_parsing.py's isdigit()/int()
+findings: export_utils.py's cell-splitting functions (_cell_header,
+_is_solution_cell, _split_directives, make_stub_variant,
+make_solution_variant), core/modules.py's lightweight YAML parser, and
+test_runner.py's subprocess-output parsers (_parse_test_output,
+_parse_pytest_output, _extract_pytest_error).
+
+These process real file/subprocess content, not just CLI args, so
+malformed content is a genuine (if narrower) attack surface -- a
+corrupted source file or an unexpected pytest output format shouldn't be
+able to crash anything with something other than export_utils.py's own
+deliberate, typed UnpairedSolutionCellError. Every function fuzzed here
+came back clean (no new bug found) -- this is confirmatory coverage, not
+a bug-fix commit, unlike test_fuzz_number_parsing.py.
+"""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from platforms.cli.commands.export_utils import (
+    UnpairedSolutionCellError,
+    _cell_header,
+    _is_solution_cell,
+    _split_directives,
+    make_solution_variant,
+    make_stub_variant,
+)
+from platforms.cli.core.modules import _parse_yaml_file
+from platforms.cli.processes.module_workflow.test_runner import (
+    _extract_pytest_error,
+    _parse_pytest_output,
+    _parse_test_output,
+)
+
+# ---------------------------------------------------------------------------
+# Cell-level helpers: must never raise, for any text
+# ---------------------------------------------------------------------------
+
+
+@given(st.text())
+def test_cell_header_never_raises(cell_text):
+    assert isinstance(_cell_header(cell_text), str)
+
+
+@given(st.text())
+def test_is_solution_cell_never_raises(cell_text):
+    assert isinstance(_is_solution_cell(cell_text), bool)
+
+
+@given(st.text())
+def test_split_directives_never_raises(cell_text):
+    header_line, directive_lines, body = _split_directives(cell_text)
+    assert isinstance(header_line, str)
+    assert isinstance(directive_lines, list)
+    assert isinstance(body, str)
+
+
+# ---------------------------------------------------------------------------
+# make_stub_variant / make_solution_variant: the only allowed exception is
+# their own deliberate UnpairedSolutionCellError -- anything else (IndexError,
+# KeyError, etc.) would be a real crash bug.
+# ---------------------------------------------------------------------------
+
+
+@given(st.text())
+@settings(max_examples=300)
+def test_make_stub_variant_never_crashes_unexpectedly(source):
+    try:
+        result = make_stub_variant(source)
+        assert isinstance(result, str)
+    except UnpairedSolutionCellError:
+        pass  # deliberate, typed -- not a crash
+
+
+@given(st.text())
+@settings(max_examples=300)
+def test_make_solution_variant_never_crashes_unexpectedly(source):
+    try:
+        result = make_solution_variant(source)
+        assert isinstance(result, str)
+    except UnpairedSolutionCellError:
+        pass
+
+
+# A structured strategy that actually generates realistic-ish cell soup
+# (multiple "# %%" cells, some solution-tagged, some not, with directive
+# lines and blank-line noise) rather than only fully random text -- random
+# text alone almost never contains "# %%" or the solution tag literal, so
+# it can't reach the pairing logic's real branches.
+_CELL_HEADER = st.sampled_from(
+    [
+        "# %%",
+        '# %% tags=["solution"]',
+        "# %% tags=['solution']",
+        '# %% tags=["solution", "hidden"]',
+    ]
+)
+_DIRECTIVE_LINE = st.sampled_from(["#| export", "#| default_exp core.tensor", "#| hide"])
+_BODY_LINE = st.text(alphabet=st.characters(blacklist_characters="\n"), max_size=20)
+
+
+@st.composite
+def _cell_soup(draw):
+    n_cells = draw(st.integers(min_value=0, max_value=6))
+    parts = []
+    for _ in range(n_cells):
+        header = draw(_CELL_HEADER)
+        n_directives = draw(st.integers(min_value=0, max_value=2))
+        directives = [draw(_DIRECTIVE_LINE) for _ in range(n_directives)]
+        n_body_lines = draw(st.integers(min_value=0, max_value=3))
+        body_lines = [draw(_BODY_LINE) for _ in range(n_body_lines)]
+        parts.append("\n".join([header, *directives, *body_lines]))
+    return "\n".join(parts)
+
+
+@given(_cell_soup())
+@settings(max_examples=300)
+def test_make_stub_variant_handles_structured_cell_soup(source):
+    try:
+        make_stub_variant(source)
+    except UnpairedSolutionCellError:
+        pass
+
+
+@given(_cell_soup())
+@settings(max_examples=300)
+def test_make_solution_variant_handles_structured_cell_soup(source):
+    try:
+        make_solution_variant(source)
+    except UnpairedSolutionCellError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _parse_yaml_file (core/modules.py's lightweight module.yaml reader)
+# ---------------------------------------------------------------------------
+
+
+@given(st.text())
+def test_parse_yaml_file_never_raises(content):
+    result = _parse_yaml_file(content)
+    assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# test_runner.py's subprocess-output parsers: real pytest/inline-test stdout
+# and stderr, not just any string, but the format can shift (a pytest
+# version bump, a truncated capture, an unrelated crash dumping a traceback
+# instead of the expected markers) -- these must degrade gracefully, never
+# raise, for arbitrary text standing in for "output we didn't expect."
+# ---------------------------------------------------------------------------
+
+
+@given(st.text(), st.text(), st.integers(min_value=-2, max_value=255))
+@settings(max_examples=300)
+def test_parse_test_output_never_raises(stdout, stderr, returncode):
+    result = _parse_test_output(stdout, stderr, returncode)
+    assert isinstance(result, list)
+
+
+@given(st.text(), st.text())
+@settings(max_examples=300)
+def test_parse_pytest_output_never_raises(stdout, stderr):
+    result = _parse_pytest_output(stdout, stderr)
+    assert isinstance(result, list)
+
+
+@given(st.text(), st.text(), st.text())
+@settings(max_examples=300)
+def test_extract_pytest_error_never_raises(stdout, stderr, test_path):
+    result = _extract_pytest_error(stdout, stderr, test_path)
+    assert result is None or isinstance(result, str)
+
+
+# Structured strategy generating text that actually contains the markers
+# these parsers look for ("::", "PASSED"/"FAILED", "✅"/"❌"), so fuzzing
+# reaches the real parsing branches rather than only the early-exit path.
+_PYTEST_LINE = st.sampled_from(
+    [
+        "tests/01_tensor/test_x.py::TestClass::test_method PASSED",
+        "tests/01_tensor/test_x.py::test_bare FAILED",
+        "tests/01_tensor/test_x.py FAILED",
+        "::just_colons::PASSED",
+        "PASSED",
+        "",
+    ]
+)
+_INLINE_LINE = st.sampled_from(
+    ["✅ test_one", "❌ test_two: AssertionError boom", "❌", "✅:", "random line"]
+)
+
+
+@given(st.lists(_PYTEST_LINE, max_size=8).map("\n".join), st.text())
+@settings(max_examples=300)
+def test_parse_pytest_output_handles_marker_soup(stdout, stderr):
+    result = _parse_pytest_output(stdout, stderr)
+    assert isinstance(result, list)
+
+
+@given(st.lists(_INLINE_LINE, max_size=8).map("\n".join), st.text(), st.integers(min_value=0, max_value=1))
+@settings(max_examples=300)
+def test_parse_test_output_handles_marker_soup(stdout, stderr, returncode):
+    result = _parse_test_output(stdout, stderr, returncode)
+    assert isinstance(result, list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ PyYAML>=6.0.3
 pytest>=9.0.3
 pytest-cov>=7.1.0
 pytest-xdist>=3.8.0
+hypothesis>=6.100.0
 
 # ============================================================================
 # Development Tools (Required for tito export)


### PR DESCRIPTION
Ran a fuzz-testing survey across platforms/cli/, targeting every function that parses raw external text (CLI args, file content, subprocess output, and -- most importantly -- real HTTP request data) without full validation. Tracked in #72.

## Bugs found and fixed

### 1. `server/handler.py`: a real, network-reachable urlparse() crash (highest severity -- genuine attacker-controlled input, not just a local CLI arg)

`urlparse()` raises `ValueError` on a malformed IPv6-looking authority (e.g. `http://[::1`, an unclosed bracket). Two call sites had no try/except:

- `_request_is_local` (reads the `Origin` header, gates every API call) and `do_OPTIONS` both called `urlparse(origin).hostname` directly.
- `do_GET`/`do_POST` called `urlparse(self.path)` on the raw request target as their very first line, before any routing.

Mutation-verified this was genuinely unhandled: reverting the fix and sending the malformed request produces a traceback from inside socketserver's own request thread, and the client gets `RemoteDisconnected` (connection closed, no response at all).

Fixed with a `_safe_hostname()` helper and a try/except around `urlparse(self.path)` returning a clean 400. Also discovered and documented (not exploited): a same-shaped `//[::1/x` origin-form target doesn't reach the crash, because Python's own `http.server` already collapses a leading `//` to a single `/` (an unrelated open-redirect hardening) -- verified directly and pinned with its own regression test so the fix's coverage doesn't rest on the wrong reproduction case.

### 2. The common `if s.isdigit(): int(s)` pattern

`str.isdigit()` returns True for 128 distinct Unicode code points that `int()` then rejects with ValueError -- so that pattern is only safe against ASCII digits, not arbitrary text. Two real, reachable crashes:

- **`core/modules.py`'s `normalize_module_number`**: reachable directly from any CLI module-number argument.
- **`module_workflow/workflow.py`'s `completed_nums`**: reachable through `progress.json`'s `completed_modules` list, which isn't schema-validated.

## Confirmatory coverage (no bug found, verified anyway)

`export_utils.py`'s cell-splitting functions, `core/modules.py`'s lightweight YAML parser, and `test_runner.py`'s subprocess-output parsers -- all 13 tests pass on the first run, confirming the earlier MC/DC hardening holds up under genuinely adversarial input.

## Verification

- `test_fuzz_number_parsing.py`, `test_fuzz_text_parsers.py`, `test_fuzz_server_handler.py`: Hypothesis property tests plus concrete regression examples and real end-to-end HTTP requests against a live server instance
- Both fixes mutation-tested: reverted locally, confirmed the tests fail exactly as expected, then restored
- 445 local tests pass, `ruff check`/`ruff format --check` clean
- `hypothesis` added to `requirements.txt` so CI can run these

## What's left

#72 tracks the remaining batches (`cli_platform/`, `processes/`, `tui/`) for a follow-up pass.