### PR TITLE
Fuzz survey Batch 2 (cli_platform/): fix a live-streaming truncation bug

### DIFF
--- a/platforms/cli/cli_platform/dev/test.py
+++ b/platforms/cli/cli_platform/dev/test.py
@@ -501,8 +501,16 @@ class DevTestCommand(BaseCommand):
                             status = "!"
                         else:
                             status = "-"
-                        # Extract just the test name
-                        test_name = line.split("::")[-1].split()[0] if "::" in line else line
+                        # Extract just the test name. "::" is guaranteed
+                        # present here (the outer if already checked), but
+                        # the part after it being nothing but whitespace
+                        # (so .split() returns []) isn't -- that used to
+                        # raise IndexError here, caught by this method's
+                        # own outer except Exception, which silently
+                        # truncated live CI test-streaming mid-run instead
+                        # of just skipping this one unparseable line.
+                        name_parts = line.split("::")[-1].split()
+                        test_name = name_parts[0] if name_parts else line
                         print(f"  {status} {test_name}")
                         test_count += 1
                     elif line.startswith("ERROR "):

--- a/platforms/cli/tests/test_fuzz_dev_test_pytest_streaming.py
+++ b/platforms/cli/tests/test_fuzz_dev_test_pytest_streaming.py
@@ -1,0 +1,117 @@
+"""
+Fuzz coverage for dev/test.py's _run_pytest CI-mode live-streaming
+test-name extraction, batch 2 of the fuzz-testing survey (issue #72).
+
+Found by fuzzing: `line.split("::")[-1].split()[0]` raised IndexError
+whenever the text after the last "::" was empty or all-whitespace (e.g.
+"tests/x.py::   PASSED" -- unusual but not something pytest's own output
+format actually guarantees never happens, since this only checks "::" is
+present anywhere in the line and " PASSED"/" FAILED"/" ERROR"/" SKIPPED"
+appears, not that a real test id follows the last "::").
+
+This is caught by _run_pytest's own outer `except Exception`, so it
+doesn't crash the CLI -- but it does silently truncate live CI test
+streaming mid-run, replacing real test-by-test visibility with a generic
+"list index out of range" TestResult failure. Confirmed via mutation
+testing (reverting the fix reproduces exactly that truncation) before
+fixing.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from platforms.cli.cli_platform.dev.test import DevTestCommand
+from platforms.cli.core.config import CLIConfig
+
+TRENTORCH_ROOT = Path(__file__).resolve().parents[3]
+
+
+class _FakeProcess:
+    def __init__(self, lines, returncode=0):
+        self.stdout = iter(lines)
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def _run_ci_pytest(lines):
+    """Uses unittest.mock.patch as a context manager (not the monkeypatch
+    fixture) so this is safe to call from inside a Hypothesis @given body
+    -- monkeypatch is function-scoped and doesn't reset between generated
+    examples, which Hypothesis flags as a health-check failure."""
+    with patch.object(subprocess, "Popen", lambda *a, **k: _FakeProcess(lines)):
+        cmd = DevTestCommand(CLIConfig.from_project_root(TRENTORCH_ROOT))
+        return cmd._run_pytest(TRENTORCH_ROOT, "platforms/cli", "unit", verbose=False, ci_mode=True)
+
+
+def test_line_with_nothing_after_the_last_colons_does_not_crash_streaming(capsys):
+    """The concrete regression case: "::" present, " PASSED" present
+    (the outer guard only checks these appear *somewhere* in the line,
+    not that the marker follows the last "::"), and the text after the
+    line's *last* "::" is empty. " PASSED::" satisfies both: the marker
+    comes before the trailing "::", so splitting on "::" leaves nothing
+    after it. Before the fix, this IndexError'd out of the whole
+    streaming loop -- every line after it in the same pytest run went
+    unreported, and the TestResult's message became the raw exception
+    text instead of a real summary."""
+    result = _run_ci_pytest([" PASSED::", "tests/y.py::test_after PASSED"])
+    out = capsys.readouterr().out
+    assert "list index out of range" not in (result.message or "")
+    # The line *after* the malformed one must still have been processed --
+    # this is the actual symptom of the bug, not just "didn't raise".
+    assert "test_after" in out
+
+
+@given(st.lists(st.text(), max_size=6))
+@settings(max_examples=200)
+def test_run_pytest_ci_streaming_never_crashes_on_arbitrary_lines(lines):
+    """Broad fuzz: whatever subprocess stdout throws at the live-stream
+    parser, _run_pytest itself must return a TestResult (it always did --
+    there's an outer except Exception), AND that result's message must
+    never be a raw Python exception string leaking an internal parsing
+    detail to the user instead of a real test summary. That second
+    assertion is the one that actually distinguishes "fixed" from
+    "merely doesn't crash the process" -- the bug this file exists for
+    was already caught by the outer except before the fix; what it
+    didn't do was avoid corrupting the reported outcome."""
+    result = _run_ci_pytest(lines)
+    assert result is not None
+    assert hasattr(result, "passed")
+    assert "index out of range" not in (result.message or "")
+
+
+# Structured strategy that actually contains the markers the parser looks
+# for ("::", " PASSED"/" FAILED"/" ERROR"/" SKIPPED"), so fuzzing reaches
+# the real test-name-extraction branch instead of only the early-exit path.
+# The " PASSED::"-shaped entries are the ones that actually trigger the
+# original bug: the marker appears *before* the line's last "::", so
+# splitting on "::" leaves nothing after it to extract a name from.
+_MARKER_LINE = st.sampled_from(
+    [
+        "tests/x.py::test_a PASSED",
+        "tests/x.py:: PASSED",
+        "tests/x.py::   PASSED",
+        "::PASSED",
+        " PASSED::",
+        " FAILED::",
+        " ERROR::",
+        " SKIPPED::",
+        "a::b::c FAILED",
+        "no colons here PASSED",
+        "tests/x.py::test_b ERROR",
+        "tests/x.py::test_c SKIPPED",
+    ]
+)
+
+
+@given(st.lists(_MARKER_LINE, max_size=8))
+@settings(max_examples=200)
+def test_run_pytest_ci_streaming_handles_marker_soup(lines):
+    result = _run_ci_pytest(lines)
+    assert result is not None
+    assert "index out of range" not in (result.message or "")


### PR DESCRIPTION
Batch 2 of the fuzz-testing survey tracked in #72: `cli_platform/system/`, `cli_platform/dev/`, `cli_platform/package/`, `core/virtual_env_manager.py`.

## Bug found and fixed

`dev/test.py`'s `_run_pytest` CI-mode live-streaming test-name extraction: `line.split('::')[-1].split()[0]` raises `IndexError` whenever the text after the line's *last* `::` is empty -- which the outer guard doesn't prevent, since it only checks `::` and a PASSED/FAILED/ERROR/SKIPPED marker appear *somewhere* in the line, not that the marker follows the last `::`. A line like `" PASSED::"` (marker before the trailing `::`) triggers it.

This is caught by `_run_pytest`'s own outer `except Exception`, so it never crashed the CLI process -- but it did silently truncate live CI test streaming mid-run: every subsequent line in that pytest invocation went unreported, and the `TestResult`'s message became the raw "list index out of range" exception text instead of a real summary.

Worth calling out: a broad "never raises past this boundary" fuzz test doesn't actually catch this, since the outer `except` already guaranteed that. The property that actually distinguishes fixed from broken is "the result message is never a leaked implementation-detail exception string" -- that's what the new tests assert, after the first version of them passed against the *unfixed* code and I had to go back and fix the test itself.

Fixed by guarding the post-split indexing instead of assuming a non-empty result.

## Reviewed, confirmed safe (no fix needed)

- `dev/test.py`'s other `int()`/`split()` call sites: the "N passed" count regex uses `\d+` (Unicode Nd category), verified against the full Unicode range to never mismatch `int()` the way `str.isdigit()` does (unlike the bug PR #70 fixed); the module-number `int()` conversions are gated behind `module_mapping` membership checks, same pattern as PR #70
- `system/update.py`'s two `json.loads()` calls on GitHub API responses: both wrapped in try/except, `dict.get()` with defaults throughout
- `system/health.py`'s `json.loads()` calls: wrapped in a method-level `except Exception: pass`
- `cli_platform/package/*.py`, `system/{system,jupyter,logo,info}.py`, `dev/{dev,clean}.py`: no unguarded parsing of unvalidated external text found
- `dev/preflight.py`: every `int()` call is `int((time.time() - start) * 1000)` (always a valid float); every `.split('\n')` is bounded slicing with no further indexing risk
- `core/virtual_env_manager.py`'s `VENV_PATH` env var handling: not wrapped, but it's a value only the same user running `tren` can set on their own machine -- not external input, and an error on a self-inflicted broken value is the correct outcome

## Verification

- `test_fuzz_dev_test_pytest_streaming.py`: Hypothesis property tests plus a concrete regression example, using the existing `_FakeProcess`/`subprocess.Popen`-patching pattern from `test_dev_test_pytest_output_parsing.py`
- Mutation-tested: reverted the fix locally, confirmed the structured fuzz test fails, then restored
- 448 local tests pass, `ruff check`/`ruff format --check` clean
