### PR TITLE
Fuzz survey Batch 3 (processes/): harden a dead-code landmine

### DIFF
--- a/platforms/cli/processes/module_workflow/workflow.py
+++ b/platforms/cli/processes/module_workflow/workflow.py
@@ -979,7 +979,15 @@ class ModuleWorkflowCommand(BaseCommand):
     def show_next_steps(self, completed_module: str) -> None:
         """Show next steps after completing a module."""
         module_mapping = get_module_mapping()
-        completed_num = int(completed_module)
+        try:
+            completed_num = int(completed_module)
+        except ValueError:
+            # Not currently reachable from any real call site (every caller
+            # of the complete workflow already validates the module number
+            # via module_mapping before this point), but nothing enforces
+            # that at this function's own boundary, so a non-numeric input
+            # shouldn't be able to crash it.
+            return
         next_num = f"{completed_num + 1:02d}"
 
         if next_num in module_mapping:

--- a/platforms/cli/tests/test_fuzz_workflow_show_next_steps.py
+++ b/platforms/cli/tests/test_fuzz_workflow_show_next_steps.py
@@ -1,0 +1,56 @@
+"""
+Fuzz coverage for module_workflow/workflow.py's show_next_steps, batch 3
+of the fuzz-testing survey (issue #72).
+
+show_next_steps(completed_module: str) called int(completed_module) with
+no guard. It isn't reachable from any real CLI code path today (every
+caller of the complete workflow already validates the module number via
+module_mapping before a point that would lead here -- confirmed by
+grepping the codebase for callers: the only one is this file's own test),
+but nothing at the function's own boundary enforces that, so a future
+caller (or a refactor that removes the upstream guard) could hand it
+unvalidated input and crash. Fixed defensively since the cost was two
+lines and the alternative is a landmine with no test coverage of its own
+input validation.
+"""
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from rich.console import Console
+
+from platforms.cli.core.config import CLIConfig
+from platforms.cli.processes.module_workflow.workflow import ModuleWorkflowCommand
+
+TRENTORCH_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def command():
+    cmd = ModuleWorkflowCommand(CLIConfig.from_project_root(TRENTORCH_ROOT))
+    cmd.console = Console(file=StringIO(), width=120, no_color=True)
+    return cmd
+
+
+@given(st.text())
+@settings(max_examples=200)
+def test_show_next_steps_never_raises(text):
+    """Broad fuzz: no string handed to this should be able to crash it."""
+    cmd = ModuleWorkflowCommand(CLIConfig.from_project_root(TRENTORCH_ROOT))
+    cmd.console = Console(file=StringIO(), width=120, no_color=True)
+    cmd.show_next_steps(text)  # must not raise
+
+
+def test_show_next_steps_handles_non_numeric_module_id(command):
+    """The concrete regression case: int() on a non-numeric string used
+    to raise ValueError, uncaught, straight out of this function."""
+    command.show_next_steps("not-a-number")  # must not raise
+
+
+def test_show_next_steps_still_works_for_a_real_module(command):
+    command.show_next_steps("01")
+    out = command.console.file.getvalue()
+    assert "Module 01" in out


### PR DESCRIPTION
Batch 3 of the fuzz-testing survey tracked in #72: `processes/milestone/`, `processes/module_workflow/`, `processes/convert.py`, `processes/olympics.py`, `commands/base.py`, `commands/jupyter.py`.

## Found and fixed (defensive, not a reachable crash today)

`module_workflow/workflow.py`'s `show_next_steps(completed_module: str)` called `int(completed_module)` with no guard. Grepped the whole codebase for callers: the only one is this file's own test (`test_release_regressions.py`), calling it with a hardcoded `"01"` -- every real caller of the module-completion workflow already validates the module number via `module_mapping` before any path that would reach this function.

Fixed anyway (wrapped in try/except ValueError, returns early) since it's a two-line change and the alternative is a landmine with no input-validation coverage of its own, waiting for a future caller or refactor to remove the upstream guard.

## Reviewed, confirmed already safe

- `milestone/command.py:655`'s `int(mod.split('_')[0])` (parsing `progress.json`'s `completed_modules` for the "what's next" hint) -- already wrapped in its own try/except `(ValueError, IndexError)`
- `milestone/system.py`: every `int()` conversion routes through the already-safe `_module_progress_to_int` helper (fixed in PR #70)
- `module_workflow/workflow.py`'s other `int()` call sites (`module_num = int(normalized)`, `sorted(..., key=lambda x: int(x))`, the status-table loop): all gated behind `module_mapping` membership checks or iterate `module_mapping`'s own keys directly, same pattern as PR #70
- `commands/export_utils.py`'s `validate_notebook_integrity` and `commands/jupyter.py`'s kernel.json read: both `json.loads()` calls wrapped in try/except
- `processes/convert.py`, `processes/olympics.py`, `module_workflow/reset.py`: no unguarded parsing of unvalidated external text found
- `milestone/display.py`'s progress-bar `int()` cast: pure float arithmetic on internal counts, never a parsed string

## Verification

- `test_fuzz_workflow_show_next_steps.py`: Hypothesis property test plus concrete regression example
- Mutation-tested: reverted the fix locally, confirmed the tests fail exactly as expected, then restored
- 448 local tests pass, `ruff check`/`ruff format --check` clean
