### PR TITLE
Fuzz survey Batch 4 (tui/): confirmatory coverage, closes #72

### DIFF
--- a/platforms/cli/tests/test_fuzz_tui_app.py
+++ b/platforms/cli/tests/test_fuzz_tui_app.py
@@ -1,0 +1,61 @@
+"""
+Fuzz coverage for tui/app.py, batch 4 (final batch) of the fuzz-testing
+survey (issue #72).
+
+Survey result for this batch: no new bug found. The TUI has no free-text
+input widgets at all (it's purely OptionList/Button-driven -- grepped for
+`Input(` and found none), so the only external string that ever reaches
+it is `--module`/`-m`'s value, passed straight into
+TrenTorchApp.__init__ -> normalize_module_number(), the exact function
+PR #70 already fixed and fuzz-tested. Every index-based access found
+(milestone_keys[index]) is already bounds-checked, and the one other
+int() call site (milestone required_modules) operates on hardcoded
+curriculum data in constants.py, not external input.
+
+This file is confirmatory: it fuzzes the actual TrenTorchApp constructor
+end-to-end (not just the underlying normalize_module_number function in
+isolation, which is already covered by test_fuzz_number_parsing.py) to
+prove the whole integration point holds, the way test_fuzz_text_parsers.py
+did for export_utils.py's already-hardened cell-splitting logic.
+"""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from platforms.cli.core.config import CLIConfig
+
+pytest.importorskip("textual")
+
+from platforms.cli.tui.app import TrenTorchApp  # noqa: E402  (after importorskip)
+
+
+@given(st.one_of(st.none(), st.text()))
+@settings(max_examples=200, deadline=None)
+def test_app_construction_never_raises_on_arbitrary_initial_module(initial_module):
+    """No string handed to --module should be able to crash TUI startup
+    before a single frame is even drawn."""
+    config = CLIConfig.from_project_root()
+    app = TrenTorchApp(config=config, initial_module=initial_module)
+    assert app.initial_module  # always resolves to *something*, never blows up
+
+
+def test_app_construction_handles_isdigit_but_unparseable_char():
+    """The specific Unicode-digit character class PR #70 fixed
+    (str.isdigit() True, int() raises), exercised through the real
+    TUI entry point this time, not the underlying function directly."""
+    config = CLIConfig.from_project_root()
+    app = TrenTorchApp(config=config, initial_module="²")
+    assert app.initial_module == "²"
+
+
+def test_app_construction_still_resolves_a_real_module():
+    config = CLIConfig.from_project_root()
+    app = TrenTorchApp(config=config, initial_module="1")
+    assert app.initial_module == "01"
+
+
+def test_app_construction_defaults_when_no_module_given():
+    config = CLIConfig.from_project_root()
+    app = TrenTorchApp(config=config, initial_module=None)
+    assert app.initial_module == "01"


### PR DESCRIPTION
Batch 4 (final batch) of the fuzz-testing survey tracked in #72: `tui/app.py`, `tui/command.py`. Closes #72.

## Survey result: no new bug found

The TUI has no free-text input widgets at all -- it's purely OptionList/Button-driven (grepped for `Input(` and found none), so the only external string that ever reaches it is `--module`/`-m`'s value, passed straight into `TrenTorchApp.__init__` -> `normalize_module_number()`, the exact function PR #70 already fixed and fuzz-tested. Every index-based access found (`milestone_keys[index]`) is already bounds-checked, and the one other `int()` call site (milestone `required_modules`) operates on hardcoded curriculum data in `constants.py` (already plain ints, not strings), not external input.

`test_fuzz_tui_app.py` is confirmatory: it fuzzes the actual `TrenTorchApp` constructor end-to-end (not just the underlying `normalize_module_number` function in isolation, already covered by `test_fuzz_number_parsing.py`) to prove the whole integration point holds, the way `test_fuzz_text_parsers.py` did for `export_utils.py`'s already-hardened cell-splitting logic.

`command.py` reviewed too: `--module` is argparse `type=str` with no further unguarded parsing; the `ModuleNotFoundError` handling for the optional `textual` dependency uses `.split('.')[0]` on `exc.name`, which always returns at least one element even for an empty string.

## Closes #72

All four planned batches (`server/`, `cli_platform/`, `processes/`, `tui/`) are now done. Total across the whole survey:

- **3 real bugs found and fixed**: a network-reachable crash in the companion server (`urlparse()` on a malformed Origin header/request path), a live-streaming truncation bug in `dev test`'s CI pytest output parsing, and a dead-code landmine in `show_next_steps`
- **1 systematic bug class identified and fixed at both genuinely reachable call sites**: the `isdigit()`/`int()` mismatch (128 Unicode code points where `str.isdigit()` is True but `int()` raises)
- Confirmatory Hypothesis fuzz coverage added across every complex text-parsing surface in `platforms/cli/` along the way (notebook cell-splitting, the lightweight YAML parser, pytest-output parsers, and now the TUI's own entry point)

## Verification

- `test_fuzz_tui_app.py`: 4 tests, all pass on the first run (no fix needed, purely confirmatory)
- 455 local tests pass, `ruff check`/`ruff format --check` clean
