### PR TITLE
feat: add Dependabot auto-merge and stale-assignment sweep bots

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,77 @@
+name: 'Dependabot Auto-merge'
+
+# Dependabot already opens PRs for outdated actions/pip deps (see
+# dependabot.yml), but they just sat there needing a manual merge even
+# after CI was green -- routine noise for updates that carry basically no
+# risk. This approves and enables auto-merge for patch/minor updates only,
+# the moment their metadata says so; a major-version bump (the kind that
+# actually can break something) is deliberately left alone for a human to
+# look at.
+#
+# "Enable auto-merge" (`gh pr merge --auto`), not an immediate merge: it
+# asks GitHub to merge once the PR's normal requirements (the required
+# Analyze/Ruff/Summary checks) are satisfied on its own, rather than
+# forcing it through early or bypassing branch protection the way the
+# admin-merge bots elsewhere in this repo do. The approval step is what
+# actually clears this repo's 1-review requirement -- needed since
+# Dependabot can't approve its own PR, and using AUTOFIX_PAT's identity
+# (a maintainer, not the PR author) to approve isn't a self-approval.
+#
+# Uses AUTOFIX_PAT: approving/merging both go through the same "Actions
+# can't create or approve PRs with its own token" restriction this repo's
+# other PAT-gated bots already work around (see update-contributors.yml's
+# comment on the exact failure). No-ops cleanly if the secret is unset.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check AUTOFIX_PAT is configured
+        id: has-pat
+        run: |
+          if [ -z "${{ secrets.AUTOFIX_PAT }}" ]; then
+            echo "::notice::AUTOFIX_PAT secret isn't set yet -- skipping. Dependabot PRs still need a manual review/merge for now."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch Dependabot metadata
+        if: steps.has-pat.outputs.configured == 'true'
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.AUTOFIX_PAT }}
+
+      - name: Approve and enable auto-merge (patch/minor only)
+        if: |
+          steps.has-pat.outputs.configured == 'true' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ secrets.AUTOFIX_PAT }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.metadata.outputs.update-type }} update to \`${{ steps.metadata.outputs.dependency-names }}\`."
+          gh pr merge "$PR_URL" --squash --auto --delete-branch
+
+      - name: Leave a note on major bumps
+        if: |
+          steps.has-pat.outputs.configured == 'true' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.AUTOFIX_PAT }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr comment "$PR_URL" --body "This is a major-version bump (\`${{ steps.metadata.outputs.dependency-names }}\`), left for manual review rather than auto-merged."

--- a/.github/workflows/stale-assignment-sweep.yml
+++ b/.github/workflows/stale-assignment-sweep.yml
@@ -1,0 +1,151 @@
+name: 'Stale Assignment Sweep'
+
+# require-linked-issue.yml enforces "get the issue assigned to you, then
+# PR it" so credit-stealers can't swoop in on someone else's assigned
+# issue -- but that same rule means an issue assigned-and-abandoned just
+# sits blocked forever, with no way in for someone who'd actually do the
+# work. This finds open issues that have been assigned for 7+ days with
+# no PR from the assignee referencing them, warns on the issue, and
+# unassigns after another 7 days of continued silence so the issue goes
+# back up for grabs.
+#
+# "PR referencing them" is checked the same way require-linked-issue.yml
+# checks it (a closing-keyword search), via the Search API scoped to the
+# assignee as author -- so someone who opened a PR but forgot the magic
+# words wouldn't be swept; that's an acceptable false-negative here since
+# the cost of wrongly leaving an active contributor's issue alone is a lot
+# lower than wrongly unassigning them.
+#
+# Runs daily; a week-plus staleness threshold doesn't need finer granularity.
+
+on:
+  schedule:
+    - cron: '43 4 * * *'  # once a day, minute offset from :00
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const WARN_LABEL = "stale-assignment";
+            const WARN_DAYS = 7;
+            const UNASSIGN_DAYS = 7; // additional days after the warning
+            const MARKER = "<!-- stale-assignment-warning -->";
+            const now = Date.now();
+            const daysAgo = (iso) => (now - new Date(iso).getTime()) / 86400000;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              assignee: "*",
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue; // PRs show up in this listing too
+              if (!issue.assignees || issue.assignees.length === 0) continue;
+
+              const labels = (issue.labels || []).map((l) => (typeof l === "string" ? l : l.name));
+              const alreadyWarned = labels.includes(WARN_LABEL);
+
+              // Has any assignee already opened a PR referencing this issue?
+              let hasReferencingPr = false;
+              for (const assignee of issue.assignees) {
+                const q = `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${assignee.login} in:body #${issue.number}`;
+                const { data } = await github.rest.search.issuesAndPullRequests({ q });
+                if (data.total_count > 0) {
+                  hasReferencingPr = true;
+                  break;
+                }
+              }
+              if (hasReferencingPr) {
+                if (alreadyWarned) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: WARN_LABEL,
+                  }).catch(() => {});
+                }
+                continue;
+              }
+
+              if (!alreadyWarned) {
+                // How long has the current assignment stood? Use the most
+                // recent "assigned" timeline event for any current assignee,
+                // falling back to the issue's own updated_at if events are
+                // somehow unavailable.
+                const events = await github.paginate(github.rest.issues.listEvents, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 100,
+                });
+                const assigneeLogins = issue.assignees.map((a) => a.login);
+                const assignEvents = events.filter(
+                  (e) => e.event === "assigned" && e.assignee && assigneeLogins.includes(e.assignee.login)
+                );
+                const assignedAt = assignEvents.length
+                  ? assignEvents[assignEvents.length - 1].created_at
+                  : issue.updated_at;
+
+                if (daysAgo(assignedAt) < WARN_DAYS) continue;
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [WARN_LABEL],
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `${MARKER}\n⏳ This issue has been assigned for over ${WARN_DAYS} days with no linked PR yet. ` +
+                    `If you're still working on it, no action needed once a PR referencing this issue is opened. ` +
+                    `Otherwise it'll be unassigned in ${UNASSIGN_DAYS} more days so someone else can pick it up.`,
+                });
+                console.log(`#${issue.number}: warned (assigned ${assignedAt}).`);
+                continue;
+              }
+
+              // Already warned -- check how long ago, from the marker comment.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const warningComments = comments.filter((c) => (c.body || "").includes(MARKER));
+              if (warningComments.length === 0) continue; // label present but no comment found, wait for next run
+              const warnedAt = warningComments[warningComments.length - 1].created_at;
+              if (daysAgo(warnedAt) < UNASSIGN_DAYS) continue;
+
+              await github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: issue.assignees.map((a) => a.login),
+              });
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: WARN_LABEL,
+              }).catch(() => {});
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Unassigned after ${WARN_DAYS + UNASSIGN_DAYS}+ days with no linked PR. This issue is open for anyone to pick up again.`,
+              });
+              console.log(`#${issue.number}: unassigned (warned ${warnedAt}).`);
+            }


### PR DESCRIPTION
Two new bots, both PAT-gated and no-op if `AUTOFIX_PAT` is unset:

**Dependabot auto-merge** (`dependabot-auto-merge.yml`): approves and enables GitHub's native auto-merge for patch/minor Dependabot PRs once CI is green, using the fetched update-type metadata to tell patch/minor from major. Major bumps get a comment and are left for manual review. Also flips on `allow_auto_merge` at the repo level, which was off and is required for `gh pr merge --auto` to do anything.

**Stale-assignment sweep** (`stale-assignment-sweep.yml`): `require-linked-issue.yml` enforces get-assigned-then-PR, which is good for stopping credit theft but means an assigned issue can otherwise sit blocked forever with nobody working it. This runs daily, flags any open issue assigned 7+ days with no referencing PR from the assignee, warns on it, then unassigns after 7 more days of continued silence so it goes back up for grabs. Added the `stale-assignment` label it uses.

Both validated for YAML/JS syntax locally before pushing; will confirm end to end via `workflow_dispatch` once merged.