### PR TITLE
ci: add OpenSSF Scorecard, Dependency Review, and semantic PR title checks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: 'Dependency Review'
+
+# Dependabot (dependabot.yml) updates existing dependencies after a CVE or
+# new release lands -- this catches the other direction: a PR (from anyone,
+# not just Dependabot) that *introduces* a new dependency with a known
+# vulnerability or a disallowed license, blocked before merge instead of
+# discovered later in an audit. Runs only against what a PR's diff actually
+# changes, so it's fast and has nothing to do on PRs that don't touch a
+# dependency manifest at all.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: 'OpenSSF Scorecard'
+
+# CodeQL (codeql.yml) checks the code itself for bugs; Scorecard checks the
+# *process* around it -- unpinned actions, overly broad token permissions,
+# missing branch protection, binary artifacts committed to the repo, and
+# similar supply-chain risk factors CodeQL doesn't look at at all. Results
+# publish to the same Security tab CodeQL and the codeql-alert-to-issue
+# bot already watch, so nothing new to monitor separately.
+#
+# Runs on a weekly schedule (Scorecard's own recommendation, matching how
+# infrequently these process-level facts actually change) plus on push to
+# main so a real branch-protection/permissions change gets scored promptly
+# rather than waiting up to a week.
+
+on:
+  schedule:
+    - cron: '24 5 * * 3'  # weekly, Wednesday, minute/hour offset from :00
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # to upload SARIF results to the Security tab
+      id-token: write        # to sign/publish results to the public OpenSSF API
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to code scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload results as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,50 @@
+name: 'Semantic PR Title'
+
+# Enforces Conventional Commits-style PR titles (feat:, fix:, docs:, chore:,
+# etc.) at open/edit time -- this repo's own CHANGELOG.md and commit
+# history already follow that style by convention (see git log), this just
+# makes it a checked requirement instead of something that depends on
+# whoever's writing the title remembering the convention. Also what makes
+# a future release-notes-from-labels bot reliable, since it can trust the
+# type prefix instead of re-deriving it from the diff.
+#
+# pull_request_target, not pull_request, matching this repo's other
+# metadata-only bots (require-linked-issue.yml, pr-auto-assign.yml,
+# welcome.yml): only reads the PR title via the API, never checks out or
+# runs code from the PR branch.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          # A short human-readable summary is enough; this isn't gating on
+          # subject length or case, just the type prefix + colon.
+          subjectPattern: ^.+$
+          wip: true


### PR DESCRIPTION
Three new advisory (non-required-check) workflows:

**`scorecard.yml`** -- OpenSSF Scorecard, weekly + on push to main. Scores supply-chain/process posture (unpinned actions, token permissions, branch protection, binary artifacts) that CodeQL's code-level analysis doesn't look at, publishing results to the same Security tab.

**`dependency-review.yml`** -- blocks a PR's introduced dependencies if they carry a known high-severity vulnerability or a GPL/AGPL-family license. Complements Dependabot (which updates existing deps after the fact) by gating what a human PR newly adds, before merge. Checked: no current dependency would trip the license deny-list (project is MIT; numpy/rich/PyYAML/pytest/textual/etc. are all MIT/BSD/Apache).

**`semantic-pr-title.yml`** -- enforces Conventional Commits-style PR titles (`feat:`, `fix:`, `docs:`, ...), matching the convention this repo's CHANGELOG and commit history already follow by hand. Uses the default `GITHUB_TOKEN` (read PR title + write a commit status only), no PAT needed.

None of the three are in branch protection's required checks yet -- left advisory so a first real finding doesn't hard-block a PR sight-unseen. This PR's own title is intentionally semantic, dogfooding the third check.