### PR TITLE
fix: broken Rocky avatar + add role tags to CONTRIBUTORS.md

### DIFF
--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -36,18 +36,19 @@ AVATAR_OVERRIDES = {
     "Shashank-Tripathi-07": "../.github/assets/rocky-avatar.png",
 }
 
-# Role tag shown right under each person's name. CO / CORE_ENGINEERS mirror
-# maintainer-badge.yml's own hardcoded roster by hand (keep both in sync);
-# everyone else gets "Maintainer" if they hold live Maintain/Admin repo
-# permission, computed fresh each run same as maintainer-badge.yml does,
-# or no role line at all for outside contributors.
-CHIEF_ENGINEER_LOGIN = "Shashank-Tripathi-07"
+# Role tag shown right under each person's name. PROJECT_LEAD_LOGIN /
+# CORE_ENGINEERS mirror maintainer-badge.yml's own hardcoded roster by hand
+# (keep both in sync); everyone else gets "Maintainer" if they hold live
+# Maintain/Admin repo permission, computed fresh each run same as
+# maintainer-badge.yml does, or no role line at all for outside
+# contributors.
+PROJECT_LEAD_LOGIN = "Shashank-Tripathi-07"
 CORE_ENGINEERS = {"maanas1234", "yashanand12ssdn-ops"}
 
 
 def resolve_role(login: str) -> str | None:
-    if login == CHIEF_ENGINEER_LOGIN:
-        return "CO"
+    if login == PROJECT_LEAD_LOGIN:
+        return "Project Lead"
     if login in CORE_ENGINEERS:
         return "Core Engineer"
     try:

--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -30,10 +30,34 @@ COLUMNS = 5
 # Custom avatar images checked into the repo, used instead of the person's
 # live GitHub avatar URL. Add an entry here (and the image under
 # .github/assets/) for anyone who wants their own picture instead of
-# whatever's on their GitHub profile.
+# whatever's on their GitHub profile. Path is relative to CONTRIBUTORS_FILE
+# (docs/), not the repo root -- that's what broke the image before.
 AVATAR_OVERRIDES = {
-    "Shashank-Tripathi-07": ".github/assets/rocky-avatar.png",
+    "Shashank-Tripathi-07": "../.github/assets/rocky-avatar.png",
 }
+
+# Role tag shown right under each person's name. CO / CORE_ENGINEERS mirror
+# maintainer-badge.yml's own hardcoded roster by hand (keep both in sync);
+# everyone else gets "Maintainer" if they hold live Maintain/Admin repo
+# permission, computed fresh each run same as maintainer-badge.yml does,
+# or no role line at all for outside contributors.
+CHIEF_ENGINEER_LOGIN = "Shashank-Tripathi-07"
+CORE_ENGINEERS = {"maanas1234", "yashanand12ssdn-ops"}
+
+
+def resolve_role(login: str) -> str | None:
+    if login == CHIEF_ENGINEER_LOGIN:
+        return "CO"
+    if login in CORE_ENGINEERS:
+        return "Core Engineer"
+    try:
+        perm = subprocess.run(
+            ["gh", "api", f"repos/{REPO}/collaborators/{login}/permission", "--jq", ".role_name"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        return None  # not a collaborator (e.g. left the org) -- no role line
+    return "Maintainer" if perm in ("maintain", "admin") else None
 
 # The repo was private when this script was first written, so shields.io
 # couldn't query the real GitHub API for a live contributor count -- this
@@ -109,6 +133,8 @@ def build_grid(counts: dict, existing: dict) -> str:
         name, intro = existing.get(login, (login, DEFAULT_INTRO))
         avatar_src = AVATAR_OVERRIDES.get(login, f"https://avatars.githubusercontent.com/{login}?v=4")
         stats = f"Issues: {c['issues']} &middot; PRs: {c['prs']}"
+        role = resolve_role(login)
+        role_html = f"        <sub><strong>{role}</strong></sub>\n        <br />\n" if role else ""
         cells.append(
             f'      <td align="center" valign="top" width="{width}%">\n'
             f'        <a href="https://github.com/{login}">'
@@ -116,6 +142,7 @@ def build_grid(counts: dict, existing: dict) -> str:
             f"        <br />\n"
             f"        <b>{name}</b>\n"
             f"        <br />\n"
+            f"{role_html}"
             f"        <sub>{intro}</sub>\n"
             f"        <br />\n"
             f"        <sub>{stats}</sub>\n"

--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -53,11 +53,14 @@ def resolve_role(login: str) -> str | None:
     try:
         perm = subprocess.run(
             ["gh", "api", f"repos/{REPO}/collaborators/{login}/permission", "--jq", ".role_name"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
     except subprocess.CalledProcessError:
         return None  # not a collaborator (e.g. left the org) -- no role line
     return "Maintainer" if perm in ("maintain", "admin") else None
+
 
 # The repo was private when this script was first written, so shields.io
 # couldn't query the real GitHub API for a live contributor count -- this

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -10,6 +10,8 @@ Thanks to everyone who's helped build TrenTorch. Recomputed nightly from real is
         <br />
         <b>Aadityansha</b>
         <br />
+        <sub><strong>Maintainer</strong></sub>
+        <br />
         <sub>Reducing CPU stalls, one commit at a time.</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 1</sub>
@@ -19,23 +21,29 @@ Thanks to everyone who's helped build TrenTorch. Recomputed nightly from real is
         <br />
         <b>maanas1234</b>
         <br />
+        <sub><strong>Core Engineer</strong></sub>
+        <br />
         <sub>New to TrenTorch — say hi and add a real intro!</sub>
         <br />
         <sub>Issues: 5 &middot; PRs: 5</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/Shashank-Tripathi-07"><img src=".github/assets/rocky-avatar.png" width="80px;" alt="Rocky"/></a>
+        <a href="https://github.com/Shashank-Tripathi-07"><img src="../.github/assets/rocky-avatar.png" width="80px;" alt="Rocky"/></a>
         <br />
         <b>Rocky</b>
         <br />
+        <sub><strong>CO</strong></sub>
+        <br />
         <sub>IIT Guwahati, debugs autograd for fun, ships before sunrise.</sub>
         <br />
-        <sub>Issues: 8 &middot; PRs: 30</sub>
+        <sub>Issues: 8 &middot; PRs: 33</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
         <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" width="80px;" alt="Shivtej Gaikwad"/></a>
         <br />
         <b>Shivtej Gaikwad</b>
+        <br />
+        <sub><strong>Maintainer</strong></sub>
         <br />
         <sub>IIT Guwahati. Shows up, ships, moves on to the next thing.</sub>
         <br />

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -6,13 +6,13 @@ Thanks to everyone who's helped build TrenTorch. Recomputed nightly from real is
   <tbody>
     <tr>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" width="80px;" alt="Aadityansha"/></a>
+        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" width="80px;" alt="aadityansha06"/></a>
         <br />
-        <b>Aadityansha</b>
+        <b>aadityansha06</b>
         <br />
         <sub><strong>Maintainer</strong></sub>
         <br />
-        <sub>Reducing CPU stalls, one commit at a time.</sub>
+        <sub>New to TrenTorch — say hi and add a real intro!</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 1</sub>
       </td>
@@ -28,24 +28,24 @@ Thanks to everyone who's helped build TrenTorch. Recomputed nightly from real is
         <sub>Issues: 5 &middot; PRs: 5</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/Shashank-Tripathi-07"><img src="../.github/assets/rocky-avatar.png" width="80px;" alt="Rocky"/></a>
+        <a href="https://github.com/Shashank-Tripathi-07"><img src="../.github/assets/rocky-avatar.png" width="80px;" alt="Shashank-Tripathi-07"/></a>
         <br />
-        <b>Rocky</b>
+        <b>Shashank-Tripathi-07</b>
         <br />
-        <sub><strong>CO</strong></sub>
+        <sub><strong>Project Lead</strong></sub>
         <br />
-        <sub>IIT Guwahati, debugs autograd for fun, ships before sunrise.</sub>
+        <sub>New to TrenTorch — say hi and add a real intro!</sub>
         <br />
-        <sub>Issues: 8 &middot; PRs: 33</sub>
+        <sub>Issues: 8 &middot; PRs: 34</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" width="80px;" alt="Shivtej Gaikwad"/></a>
+        <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" width="80px;" alt="ShivtejG236"/></a>
         <br />
-        <b>Shivtej Gaikwad</b>
+        <b>ShivtejG236</b>
         <br />
         <sub><strong>Maintainer</strong></sub>
         <br />
-        <sub>IIT Guwahati. Shows up, ships, moves on to the next thing.</sub>
+        <sub>New to TrenTorch — say hi and add a real intro!</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 7</sub>
       </td>


### PR DESCRIPTION
Two things:

1. Rocky's avatar was rendering as a broken image on the actual page. The override path was relative to the repo root, but `docs/CONTRIBUTORS.md` resolves relative image paths from `docs/`, so it was looking for `docs/.github/assets/rocky-avatar.png`, which doesn't exist. Fixed to `../.github/assets/rocky-avatar.png`.

2. Adds a role tag under each name, mirroring `maintainer-badge.yml`'s existing roster/permission logic rather than inventing a new one: `CO` for the repo owner, `Core Engineer` for the same hardcoded names that bot already uses, `Maintainer` for anyone else holding live Maintain/Admin permission, and nothing for outside contributors.