### PR TITLE
fix: contributor regex was wiping real names/bios back to raw logins

### DIFF
--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -213,7 +213,10 @@ def selftest() -> bool:
     found = parse_existing(sample)
     ok = found.get("octocat") == ("Octo Cat", "Builds things.")
     if not ok:
-        print(f"selftest FAILED: parse_existing found {found!r}, expected the real name/bio preserved", file=sys.stderr)
+        print(
+            f"selftest FAILED: parse_existing found {found!r}, expected the real name/bio preserved",
+            file=sys.stderr,
+        )
     else:
         print("selftest passed")
     return ok

--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -84,6 +84,15 @@ CELL_RE = re.compile(
     r'<img[^>]*alt="([^"]*)"\s*/?>'
     r"</a>\s*<br\s*/?>\s*"
     r"<b>([^<]+)</b>\s*<br\s*/?>\s*"
+    # The role line (added after this regex was first written) sits between
+    # the name and the intro now -- <sub><strong>Role</strong></sub>, which
+    # a plain <sub>([^<]*)</sub> can't match through, since <strong> is a
+    # "<" this character class rejects. Skip it first, optionally, so a
+    # contributor without a role line (external, no live permission) still
+    # matches too. This exact bug wiped every real name/bio back to raw
+    # logins on this regex's first run after the role line was added --
+    # confirmed live, not assumed.
+    r"(?:<sub><strong>[^<]*</strong></sub>\s*<br\s*/?>\s*)?"
     r"<sub>([^<]*)</sub>",
     re.DOTALL,
 )
@@ -183,7 +192,37 @@ def build_grid(counts: dict, existing: dict) -> str:
     return intro + table
 
 
+def selftest() -> bool:
+    """Regression check for the bug that shipped once already: CELL_RE
+    failing to match a cell that has a role line, silently wiping the
+    person's real name/bio back to their raw login on the next run.
+    Run via --selftest, and as a pre-flight step in
+    update-contributors.yml before this script touches README.md for
+    real."""
+    sample = (
+        '<a href="https://github.com/octocat"><img src="x.png" alt="Octo Cat"/></a>\n'
+        "<br />\n"
+        "<b>Octo Cat</b>\n"
+        "<br />\n"
+        "<sub><strong>Maintainer</strong></sub>\n"
+        "<br />\n"
+        "<sub>Builds things.</sub>\n"
+        "<br />\n"
+        "<sub>Issues: 1 &middot; PRs: 2</sub>"
+    )
+    found = parse_existing(sample)
+    ok = found.get("octocat") == ("Octo Cat", "Builds things.")
+    if not ok:
+        print(f"selftest FAILED: parse_existing found {found!r}, expected the real name/bio preserved", file=sys.stderr)
+    else:
+        print("selftest passed")
+    return ok
+
+
 def main():
+    if "--selftest" in sys.argv:
+        return 0 if selftest() else 1
+
     if not README_FILE.exists():
         print("README.md not found", file=sys.stderr)
         return 1

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -69,6 +69,15 @@ jobs:
           ref: main
           token: ${{ secrets.AUTOFIX_PAT }}
 
+      # Regression guard: this script's regex parser silently wiped every
+      # real name/bio back to raw logins once already (the role line broke
+      # its own "find the existing intro" pattern). Fails loudly here
+      # instead of writing bad data to README.md again.
+      - name: Selftest the parser before touching README.md
+        if: steps.has-pat.outputs.configured == 'true'
+        run: |
+          python3 .github/scripts/update_contributors.py --selftest
+
       - name: Run update script
         if: steps.has-pat.outputs.configured == 'true'
         id: update

--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
   <tbody>
     <tr>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" width="80px;" alt="aadityansha06"/></a>
+        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" width="80px;" alt="Aadityansha"/></a>
         <br />
-        <b>aadityansha06</b>
+        <b>Aadityansha</b>
         <br />
         <sub><strong>Maintainer</strong></sub>
         <br />
-        <sub>New to TrenTorch — say hi and add a real intro!</sub>
+        <sub>Reducing CPU stalls, one commit at a time.</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 1</sub>
       </td>
@@ -331,24 +331,24 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
         <sub>Issues: 5 &middot; PRs: 5</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/Shashank-Tripathi-07"><img src=".github/assets/rocky-avatar.png" width="80px;" alt="Shashank-Tripathi-07"/></a>
+        <a href="https://github.com/Shashank-Tripathi-07"><img src=".github/assets/rocky-avatar.png" width="80px;" alt="Rocky"/></a>
         <br />
-        <b>Shashank-Tripathi-07</b>
+        <b>Rocky</b>
         <br />
         <sub><strong>Principal Maintainer</strong></sub>
         <br />
-        <sub>New to TrenTorch — say hi and add a real intro!</sub>
+        <sub>IIT Guwahati, Debugs autograd for fun, ships before sunrise.</sub>
         <br />
-        <sub>Issues: 8 &middot; PRs: 35</sub>
+        <sub>Issues: 8 &middot; PRs: 36</sub>
       </td>
       <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" width="80px;" alt="ShivtejG236"/></a>
+        <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" width="80px;" alt="Shivtej Gaikwad"/></a>
         <br />
-        <b>ShivtejG236</b>
+        <b>Shivtej Gaikwad</b>
         <br />
         <sub><strong>Maintainer</strong></sub>
         <br />
-        <sub>New to TrenTorch — say hi and add a real intro!</sub>
+        <sub>IIT Guwahati. Shows up, ships, moves on to the next thing.</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 7</sub>
       </td>


### PR DESCRIPTION
The regex that recovers each contributor's hand-written name/bio (`CELL_RE` in `update_contributors.py`) broke the moment the previous PR added a role line between the name and the intro. `<sub>([^<]*)</sub>` can't match through `<sub><strong>Role</strong></sub>`, since `<strong>` contains a `<` the character class rejects -- so `parse_existing` found nothing for anyone with a role tag, which is everyone. Confirmed live: the first scheduled/dispatched run after that PR merged actually overwrote every real name and bio in README's Team Engineers table with the raw GitHub login and the generic placeholder.

Fixed the regex to skip the optional role line first. Restored the four real names/bios by hand (README's committed content had already been overwritten, nothing left to scrape).

Added `--selftest`, wired into the workflow as a pre-flight step so this exact class of bug fails loudly before it touches README.md again -- mutation-tested: reverted the fix, confirmed selftest fails with the right symptom (`parse_existing` returns nothing), restored it.