### PR TITLE
ci: wire CI/bots for dev as the new default branch

### DIFF
--- a/.github/workflows/auto-update-behind-prs.yml
+++ b/.github/workflows/auto-update-behind-prs.yml
@@ -1,7 +1,8 @@
-name: 'Auto-update PR branches behind main'
+name: 'Auto-update PR branches behind their base'
 
-# Whenever main advances, updates every open, non-draft, same-repo PR
-# that's fallen behind via GitHub's own "update branch" API -- the exact
+# Whenever main or dev advances, updates every open, non-draft, same-repo
+# PR targeting that same branch that's fallen behind via GitHub's own
+# "update branch" API -- the exact
 # manual-rebase-through-a-CHANGELOG-conflict dance PRs #83, #84, and #88
 # all needed by hand this session. GitHub's update-branch API only
 # succeeds when there's no real conflict; a genuine conflict (like those
@@ -18,7 +19,7 @@ name: 'Auto-update PR branches behind main'
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -49,7 +50,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "open",
-              base: "main",
+              base: context.ref.replace("refs/heads/", ""),
               per_page: 100,
             });
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,7 +17,7 @@ name: 'Autofix (ruff)'
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: autofix-${{ github.event.pull_request.number }}

--- a/.github/workflows/changelog-backfill.yml
+++ b/.github/workflows/changelog-backfill.yml
@@ -23,7 +23,7 @@ name: 'Backfill CHANGELOG Reviewed-by / Merged-by on Merge'
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -47,11 +47,11 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout main
+      - name: Checkout the PR's actual base branch
         if: steps.has-pat.outputs.configured == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.AUTOFIX_PAT }}
           fetch-depth: 0
 
@@ -105,5 +105,5 @@ jobs:
           gh pr create \
             --title "docs: backfill CHANGELOG reviewer/merger for #${SOURCE_PR}" \
             --body "Automated: fills in the Reviewed-by/Merged-by columns for the CHANGELOG row #${SOURCE_PR} added, now that it's actually merged (reviewer: \`${REVIEWER}\`, merger: \`${MERGER}\`)." \
-            --base main --head "$BRANCH"
+            --base "${{ github.event.pull_request.base.ref }}" --head "$BRANCH"
           gh pr merge "$BRANCH" --squash --admin

--- a/.github/workflows/codeql-alert-to-issue.yml
+++ b/.github/workflows/codeql-alert-to-issue.yml
@@ -2,7 +2,7 @@ name: 'Open an Issue for New Code Scanning Alerts'
 
 # Alert #3 (the CORS header-injection finding, py/http-response-splitting)
 # sat in the Security tab until someone happened to go look. This opens a
-# tracking issue automatically for any open CodeQL alert on main that
+# tracking issue automatically for any open CodeQL alert on dev (the default branch) that
 # doesn't already have one. Dedups against existing open "security" issues
 # so a re-run doesn't spam duplicates for the same alert number.
 #
@@ -36,7 +36,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "open",
-              ref: "refs/heads/main",
+              ref: "refs/heads/dev",
             });
 
             if (alerts.length === 0) {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,14 +2,14 @@ name: CodeQL
 
 # Static analysis for real security bugs (injection, unsafe deserialization,
 # path traversal, etc.), not style. Free for public repos, and this repo
-# is public. Runs on every push to main, every PR, and weekly so a query
+# is public. Runs on every push to main or dev, every PR, and weekly so a query
 # pack update can surface something in code that didn't change.
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '17 3 * * 1'  # Mondays, off-peak, offset from other scheduled jobs
   workflow_dispatch:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,7 +25,7 @@ name: 'Dependabot Auto-merge'
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ name: 'Dependency Review'
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-# Ruff check (style/correctness) + format check, on every push/PR to main.
+# Ruff check (style/correctness) + format check, on every push/PR to main or dev.
 # Deliberately no paths-ignore: unlike validate.yml's test suite, this is
 # fast enough (sub-second) that skipping it for "only touches one file"
 # pushes isn't worth the required-check path-filter footgun (see
@@ -8,9 +8,9 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: lint-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,14 +9,14 @@ name: 'OpenSSF Scorecard'
 #
 # Runs on a weekly schedule (Scorecard's own recommendation, matching how
 # infrequently these process-level facts actually change) plus on push to
-# main so a real branch-protection/permissions change gets scored promptly
-# rather than waiting up to a week.
+# main or dev so a real branch-protection/permissions change gets scored
+# promptly rather than waiting up to a week.
 
 on:
   schedule:
     - cron: '24 5 * * 3'  # weekly, Wednesday, minute/hour offset from :00
   push:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch: {}
 
 permissions: read-all

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -16,7 +16,7 @@ name: 'Semantic PR Title'
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -66,7 +66,7 @@ jobs:
         if: steps.has-pat.outputs.configured == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: dev
           token: ${{ secrets.AUTOFIX_PAT }}
 
       # Regression guard: this script's regex parser silently wiped every
@@ -110,6 +110,6 @@ jobs:
           git push origin "$BRANCH"
           gh pr create --title "Update Team Engineers table" \
             --body "Automated nightly update from real issue/PR activity. See .github/workflows/update-contributors.yml." \
-            --base main --head "$BRANCH"
+            --base dev --head "$BRANCH"
           gh pr merge "$BRANCH" --squash --admin --delete-branch || \
             echo "::warning::Could not auto-merge, left open for manual merge."

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -9,9 +9,9 @@ name: 'Validate CLI Docs'
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: validate-docs-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ name: 'TrenTorch · Validate'
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths-ignore:
       - 'docs/**'
       - 'platforms/dev_tools/etc/**'

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -30,9 +30,9 @@ jobs:
           issue_message: >
             Thanks for opening your first issue on TrenTorch! 🎉
             Someone will take a look soon. In the meantime, check
-            the [Team Engineers](../blob/main/README.md#team-engineers) table — once this gets
+            the [Team Engineers](../blob/dev/README.md#team-engineers) table — once this gets
             some activity, you'll show up there automatically.
           pr_message: >
             Thanks for contributing to TrenTorch! 🎉 A maintainer will review
             this shortly. Once it merges, you'll be added to the
-            [Team Engineers](../blob/main/README.md#team-engineers) table automatically.
+            [Team Engineers](../blob/dev/README.md#team-engineers) table automatically.


### PR DESCRIPTION
dev is now the default branch; main stays protected and stable. This updates every workflow that only watched `main` so CI and the automation bots actually work now that PRs mostly target `dev`:

- Every `branches: [main]` trigger now also includes `dev`.
- `changelog-backfill.yml` / `auto-update-behind-prs.yml` no longer hardcode `main` -- they follow the PR's real `base.ref` (or whichever branch just advanced), so they work correctly against either branch.
- `update-contributors.yml` now targets `dev`.
- `codeql-alert-to-issue.yml` now polls `refs/heads/dev`.
- `welcome.yml`'s Team Engineers link now points at `blob/dev`.

Left alone: `validate.yml`'s push-to-main-specific optimization (skip redundant reruns on a PR-merge commit) still only recognizes `refs/heads/main`; pushes to `dev` just run the full suite unconditionally instead of the faster release-only path. Correct outcome, just not the fastest -- worth revisiting later if CI time on `dev` starts to matter.