### PR TITLE
fix: hash-pin ruff, close the TokenPermissions residual on run-test-stage.yml

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -59,9 +59,12 @@ jobs:
 
       - name: Install ruff
         if: steps.has-pat.outputs.configured == 'true'
-        # Exact version, matching .pre-commit-config.yaml and lint.yml
-        # (see lint.yml's comment on the same OpenSSF Scorecard finding).
-        run: pip install "ruff==0.16.4"
+        # Hash-pinned, matching .pre-commit-config.yaml and lint.yml (see
+        # lint.yml's comment on the same OpenSSF Scorecard finding and why
+        # this is a single printf line rather than a heredoc).
+        run: |
+          printf '%s\n' 'ruff==0.16.4 --hash=sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3 --hash=sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc' > /tmp/ruff-pin.txt
+          pip install --require-hashes -r /tmp/ruff-pin.txt
 
       - name: Autofix
         if: steps.has-pat.outputs.configured == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,13 +35,20 @@ jobs:
           python-version: '3.11'
 
       - name: Install ruff
-        # Exact version, matching .pre-commit-config.yaml's own ruff-pre-commit
-        # `rev: v0.16.4` -- was a floor (>=0.6.0) before, which OpenSSF
-        # Scorecard's Pinned-Dependencies check flags (an unbounded floor
-        # installs whatever's newest on the day CI runs, no one notices a
-        # version change happened). Exact match here also means CI and a
-        # contributor's local pre-commit hook lint identically.
-        run: pip install "ruff==0.16.4"
+        # Hash-pinned, matching .pre-commit-config.yaml's own ruff-pre-commit
+        # `rev: v0.16.4` -- was an unbounded floor (>=0.6.0) before, which
+        # OpenSSF Scorecard's Pinned-Dependencies check flags. ruff has zero
+        # runtime dependencies of its own (checked against PyPI's own
+        # metadata), so this is the actual PyPI-published sha256 for the
+        # exact wheel this job's runner (ubuntu-latest) resolves, not a
+        # made-up value -- `pip install --require-hashes` fails closed if it
+        # ever doesn't match. Only one platform wheel needed since this job
+        # never runs on windows-2022. One line, not a heredoc: a heredoc's
+        # closing marker has to sit at column 0 to be recognized, which
+        # doesn't survive being embedded in an indented YAML block scalar.
+        run: |
+          printf '%s\n' 'ruff==0.16.4 --hash=sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3 --hash=sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc' > /tmp/ruff-pin.txt
+          pip install --require-hashes -r /tmp/ruff-pin.txt
 
       - name: Ruff check (lint)
         run: ruff check .

--- a/.github/workflows/run-test-stage.yml
+++ b/.github/workflows/run-test-stage.yml
@@ -47,6 +47,11 @@ on:
         type: string
         default: 'true'
 
+# Empty at workflow level (matches codeql.yml / semantic-pr-title.yml's
+# pattern for the same OpenSSF Scorecard finding); the job below declares
+# the one permission it actually needs.
+permissions: {}
+
 env:
   TREN_ALLOW_SYSTEM: "1"
   TRENTORCH_QUIET: "1"

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -39,8 +39,16 @@ jobs:
         # parser, which needs the CLI's own runtime deps importable.
         # Exact versions matching this repo's own declared floors
         # (requirements.txt / pyproject.toml: rich>=15.0.0, PyYAML>=6.0.3)
-        # instead of an unbounded install, per OpenSSF Scorecard's
-        # Pinned-Dependencies check.
+        # instead of an unbounded install -- real hardening (no more
+        # "whatever's newest today"), but note this alone doesn't satisfy
+        # OpenSSF Scorecard's Pinned-Dependencies check, which specifically
+        # wants --hash pinning. rich pulls in its own dependency chain
+        # (markdown-it-py, pygments, mdurl), so hash-pinning it properly
+        # means resolving and pinning that whole chain, not just rich
+        # itself -- left as a documented gap alongside setup.sh's and
+        # run-test-stage.yml's requirements.txt installs, not silently
+        # different from them. ruff (lint.yml, autofix.yml) got the real
+        # hash-pin instead, since it has zero dependencies of its own.
         run: pip install "rich==15.0.0" "PyYAML==6.0.3"
 
       - name: Validate


### PR DESCRIPTION
Follow-up after re-running Scorecard live post-merge and checking what actually closed vs what didn't:

- **ruff** (`lint.yml`, `autofix.yml`): exact-version pinning alone didn't satisfy Scorecard's Pinned-Dependencies check (confirmed: alert stayed open at the same score). ruff has zero runtime dependencies of its own, so hash-pinning it is tractable -- pinned to the real sha256 for the manylinux x86_64 wheel + sdist, pulled from PyPI's JSON API, tested locally.
- Caught a real bug in my first attempt: a heredoc with an **indented** closing marker inside a YAML block scalar never terminates. Switched to a single `printf` line instead.
- `run-test-stage.yml`'s Token-Permissions alert was still open despite the job-level permission added last time -- added the same empty top-level `permissions: {}` that already closed this finding on `codeql.yml`/`semantic-pr-title.yml`.
- Corrected `validate-docs.yml`'s comment: exact-pinning rich/PyYAML doesn't close the Scorecard finding either (rich has its own dependency chain that would need hash-pinning too) -- now documented as the same class of gap as the `requirements.txt` installs, not silently different.