### PR TITLE
docs: add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, issues, and other contributions that are not
+aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions, and any other communication channel this project
+uses), and also applies when an individual is officially representing the
+community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer via [GitHub's private reporting
+flow](https://github.com/TrenTorch/TrenTorch/security) (Security tab →
+"Report a vulnerability" doubles as a private channel to the maintainer for
+this repo, since there's no dedicated security team or public contact
+email) or by direct-messaging [@Shashank-Tripathi-07](https://github.com/Shashank-Tripathi-07)
+on GitHub. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers,
+providing clarity around the nature of the violation and an explanation of
+why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public
+or private interaction with the people involved is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/inclusion

--- a/README.md
+++ b/README.md
@@ -392,6 +392,10 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
 
 MIT License - see [LICENSE](LICENSE) for details.
 
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Participation in issues, pull requests, and discussions is expected to stay within it.
+
 ---
 
 <div align="center">

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to TrenTorch 🔥
 
-Thanks for your interest in contributing! TrenTorch is an educational ML framework, so every contribution should make things clearer for someone learning, not just more "correct" in the abstract:
+Thanks for your interest in contributing! By participating, you're expected to uphold the [Code of Conduct](../CODE_OF_CONDUCT.md).
+
+TrenTorch is an educational ML framework, so every contribution should make things clearer for someone learning, not just more "correct" in the abstract:
 
 - **Enhance learning** — make concepts clearer for students
 - **Preserve the learning progression** — don't skip ahead of what a module has taught by that point


### PR DESCRIPTION
## Change

Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) at the repo root, linked from README.md's License section and from the top of `docs/CONTRIBUTING.md`.

## Why

Preparing to apply to Vercel's Open Source Program (`trentorch-website` is already hosted on Vercel, free $3,600/yr in platform credits, Summer 2026 cohort closes September 13) and similar programs like Netlify's. Both explicitly require a published Code of Conduct as an eligibility condition, and this repo didn't have one.

Enforcement contact points at GitHub's private security-reporting flow and the maintainer's GitHub handle, matching `SECURITY.md`'s existing pattern rather than publishing a personal email.

No code changes.