### PR TITLE
chore: fix Team Engineers grid layout and ordering

### DIFF
--- a/.github/scripts/update_contributors.py
+++ b/.github/scripts/update_contributors.py
@@ -29,8 +29,14 @@ from pathlib import Path
 REPO = "TrenTorch/TrenTorch"
 ROOT = Path(__file__).resolve().parent.parent.parent
 README_FILE = ROOT / "README.md"
-DEFAULT_INTRO = "New to TrenTorch — say hi and add a real intro!"
-COLUMNS = 5
+DEFAULT_INTRO = "Spots bugs, corrects them and contributes"
+COLUMNS = 4
+
+# Explicit display order for the established team's row, not alphabetical
+# (maintainer's own preferred lineup). Anyone introduced but not listed
+# here sorts alphabetically after it, so adding a new established member
+# later only needs a spot in this list if a specific position matters.
+PINNED_ORDER = ["maanas1234", "aadityansha06", "Shashank-Tripathi-07", "ShivtejG236"]
 
 # Custom avatar images checked into the repo, used instead of the person's
 # live GitHub avatar URL. Add an entry here (and the image under
@@ -153,7 +159,24 @@ def parse_existing(content: str):
 
 
 def build_grid(counts: dict, existing: dict) -> str:
-    logins = sorted(counts, key=lambda login: login.lower())
+    # Anyone still on the placeholder intro (hasn't written a real one yet)
+    # sorts into their own trailing group instead of alphabetically
+    # interleaving with people who have -- keeps the established team's row
+    # stable as brand-new contributors get picked up, rather than
+    # reshuffling everyone's position every time someone new shows up.
+    def has_real_intro(login: str) -> bool:
+        _, intro = existing.get(login, (login, DEFAULT_INTRO))
+        return intro != DEFAULT_INTRO
+
+    def introduced_sort_key(login: str):
+        try:
+            return (0, PINNED_ORDER.index(login))
+        except ValueError:
+            return (1, login.lower())
+
+    introduced = sorted((login for login in counts if has_real_intro(login)), key=introduced_sort_key)
+    unintroduced = sorted((login for login in counts if not has_real_intro(login)), key=str.lower)
+    logins = introduced + unintroduced
     cells = []
     width = round(100 / COLUMNS, 2)
     for login in logins:

--- a/README.md
+++ b/README.md
@@ -338,18 +338,7 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
 <table width="100%" style="width:100%">
   <tbody>
     <tr>
-      <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" class="contributor-avatar" width="80px;" alt="Aadityansha"/></a>
-        <br />
-        <b>Aadityansha</b>
-        <br />
-        <sub><strong>Maintainer</strong></sub>
-        <br />
-        <sub>Reducing CPU stalls, one commit at a time.</sub>
-        <br />
-        <sub>Issues: 0 &middot; PRs: 1</sub>
-      </td>
-      <td align="center" valign="top" width="20.0%">
+      <td align="center" valign="top" width="25.0%">
         <a href="https://github.com/maanas1234"><img src="https://avatars.githubusercontent.com/maanas1234?v=4" class="contributor-avatar" width="80px;" alt="maanas1234"/></a>
         <br />
         <b>maanas1234</b>
@@ -360,16 +349,18 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
         <br />
         <sub>Issues: 11 &middot; PRs: 12</sub>
       </td>
-      <td align="center" valign="top" width="20.0%">
-        <a href="https://github.com/MahekPatel-2403"><img src="https://avatars.githubusercontent.com/MahekPatel-2403?v=4" class="contributor-avatar" width="80px;" alt="MahekPatel-2403"/></a>
+      <td align="center" valign="top" width="25.0%">
+        <a href="https://github.com/aadityansha06"><img src="https://avatars.githubusercontent.com/aadityansha06?v=4" class="contributor-avatar" width="80px;" alt="Aadityansha"/></a>
         <br />
-        <b>MahekPatel-2403</b>
+        <b>Aadityansha</b>
         <br />
-        <sub>New to TrenTorch — say hi and add a real intro!</sub>
+        <sub><strong>Maintainer</strong></sub>
+        <br />
+        <sub>Reducing CPU stalls, one commit at a time.</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 1</sub>
       </td>
-      <td align="center" valign="top" width="20.0%">
+      <td align="center" valign="top" width="25.0%">
         <a href="https://github.com/Shashank-Tripathi-07"><img src=".github/assets/rocky-avatar.png" class="contributor-avatar" width="80px;" alt="Rocky"/></a>
         <br />
         <b>Rocky</b>
@@ -378,9 +369,9 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
         <br />
         <sub>IIT Guwahati, Debugs autograd for fun, ships before sunrise.</sub>
         <br />
-        <sub>Issues: 10 &middot; PRs: 105</sub>
+        <sub>Issues: 10 &middot; PRs: 106</sub>
       </td>
-      <td align="center" valign="top" width="20.0%">
+      <td align="center" valign="top" width="25.0%">
         <a href="https://github.com/ShivtejG236"><img src="https://avatars.githubusercontent.com/ShivtejG236?v=4" class="contributor-avatar" width="80px;" alt="Shivtej Gaikwad"/></a>
         <br />
         <b>Shivtej Gaikwad</b>
@@ -390,6 +381,17 @@ Recomputed nightly from real issue/PR activity via [`.github/workflows/update-co
         <sub>IIT Guwahati. Shows up, ships, moves on to the next thing.</sub>
         <br />
         <sub>Issues: 0 &middot; PRs: 7</sub>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="25.0%">
+        <a href="https://github.com/MahekPatel-2403"><img src="https://avatars.githubusercontent.com/MahekPatel-2403?v=4" class="contributor-avatar" width="80px;" alt="MahekPatel-2403"/></a>
+        <br />
+        <b>MahekPatel-2403</b>
+        <br />
+        <sub>Spots bugs, corrects them and contributes</sub>
+        <br />
+        <sub>Issues: 0 &middot; PRs: 1</sub>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Change

- `COLUMNS` was hardcoded to 5, which only happened to look right because there were exactly 5 contributors; a 5th one still fit on the row instead of wrapping. Set to 4.
- Added a real grouping: anyone still on the placeholder intro sorts into a trailing group instead of alphabetically interleaving with people who've been introduced, so a new contributor lands on her own row below the established team instead of splitting it.
- Explicit `PINNED_ORDER` for the established team's row: maanas1234, Aadityansha, Rocky, Shivtej Gaikwad.
- Replaced the generic "say hi and add a real intro" placeholder with a fixed one-line description for anyone not yet introduced.

## Result

Row 1: maanas1234, Aadityansha, Rocky, Shivtej Gaikwad. Row 2: MahekPatel-2403 alone.

## Verified

`--selftest` passes, and ran the script for real against live GitHub data to confirm the actual output matches (checked the regenerated README.md table directly).