### PR TITLE
style: clean up CodeFactor/pylint findings in module_workflow, dev/test, test_server

### DIFF
--- a/platforms/cli/cli_platform/dev/test.py
+++ b/platforms/cli/cli_platform/dev/test.py
@@ -393,13 +393,12 @@ class DevTestCommand(BaseCommand):
 
             if returncode == 0:
                 return TestResult(name="Build package", passed=True, duration=time.time() - start)
-            else:
-                return TestResult(
-                    name="Build package",
-                    passed=False,
-                    duration=time.time() - start,
-                    message=stderr[:200] if stderr else "Build failed",
-                )
+            return TestResult(
+                name="Build package",
+                passed=False,
+                duration=time.time() - start,
+                message=stderr[:200] if stderr else "Build failed",
+            )
         except subprocess.TimeoutExpired:
             return TestResult(
                 name="Build package",
@@ -555,16 +554,15 @@ class DevTestCommand(BaseCommand):
                         test_count=test_count,
                         message=f"{passed_count} passed",
                     )
-                else:
-                    # Include errors in the failure message
-                    total_failures = failed_count + error_count
-                    return TestResult(
-                        name=name,
-                        passed=False,
-                        duration=time.time() - start,
-                        test_count=test_count,
-                        message=f"{total_failures} failed/errors, {passed_count} passed",
-                    )
+                # Include errors in the failure message
+                total_failures = failed_count + error_count
+                return TestResult(
+                    name=name,
+                    passed=False,
+                    duration=time.time() - start,
+                    test_count=test_count,
+                    message=f"{total_failures} failed/errors, {passed_count} passed",
+                )
             else:
                 # Non-CI mode: capture output
                 result = subprocess.run(
@@ -597,18 +595,17 @@ class DevTestCommand(BaseCommand):
                         test_count=test_count,
                         message=summary,
                     )
-                else:
-                    # Extract failure info
-                    for line in result.stdout.split("\n"):
-                        if "failed" in line.lower() or "error" in line.lower():
-                            summary = line.strip()[:80]
-                            break
-                    return TestResult(
-                        name=name,
-                        passed=False,
-                        duration=time.time() - start,
-                        message=summary or "Tests failed",
-                    )
+                # Extract failure info
+                for line in result.stdout.split("\n"):
+                    if "failed" in line.lower() or "error" in line.lower():
+                        summary = line.strip()[:80]
+                        break
+                return TestResult(
+                    name=name,
+                    passed=False,
+                    duration=time.time() - start,
+                    message=summary or "Tests failed",
+                )
         except subprocess.TimeoutExpired:
             return TestResult(
                 name=name,
@@ -662,11 +659,9 @@ class DevTestCommand(BaseCommand):
                 )
             # Test up to and including the specified module
             target_int = int(module_num)
-            module_nums = [
-                m for m in sorted(module_mapping.keys(), key=lambda x: int(x)) if int(m) <= target_int
-            ]
+            module_nums = [m for m in sorted(module_mapping.keys(), key=int) if int(m) <= target_int]
         else:
-            module_nums = sorted(module_mapping.keys(), key=lambda x: int(x))
+            module_nums = sorted(module_mapping.keys(), key=int)
 
         passed_modules = 0
         failed_module = None
@@ -830,14 +825,13 @@ class DevTestCommand(BaseCommand):
                 test_count=passed_modules,
                 message=f"Failed at {failed_module}",
             )
-        else:
-            return TestResult(
-                name="Inline tests",
-                passed=True,
-                duration=duration,
-                test_count=passed_modules,
-                message=f"{passed_modules}/{len(module_nums)} modules passed",
-            )
+        return TestResult(
+            name="Inline tests",
+            passed=True,
+            duration=duration,
+            test_count=passed_modules,
+            message=f"{passed_modules}/{len(module_nums)} modules passed",
+        )
 
     def _run_unit_tests(
         self, project_root: Path, module: str | None, verbose: bool, ci_mode: bool = False
@@ -1126,15 +1120,14 @@ class DevTestCommand(BaseCommand):
                 test_count=passed_milestones,
                 message=f"{passed_milestones} milestones, reset verified",
             )
-        else:
-            failures = []
-            if failed_milestones:
-                failures.append(f"milestones: {', '.join(failed_milestones)}")
-            if not reset_ok:
-                failures.append(f"reset verification failed: {reset_detail}")
-            return TestResult(
-                name="User journey", passed=False, duration=total_time, message="; ".join(failures)[:100]
-            )
+        failures = []
+        if failed_milestones:
+            failures.append(f"milestones: {', '.join(failed_milestones)}")
+        if not reset_ok:
+            failures.append(f"reset verification failed: {reset_detail}")
+        return TestResult(
+            name="User journey", passed=False, duration=total_time, message="; ".join(failures)[:100]
+        )
 
     def _finish(self, results: list[TestResult], start_time: float, args: Namespace) -> int:
         """Show final summary and return exit code."""

--- a/platforms/cli/processes/module_workflow/workflow.py
+++ b/platforms/cli/processes/module_workflow/workflow.py
@@ -580,7 +580,6 @@ class ModuleWorkflowCommand(BaseCommand):
             _t0 = time.time()
             unit_result = run_inline_unit_tests(self.config, self.console, module_name, verbose=True)
             _profile(module_name, "step1_unit_tests", time.time() - _t0)
-            unit_result["passed"]
 
             if unit_result["failed"] > 0:
                 self.console.print()
@@ -618,15 +617,14 @@ class ModuleWorkflowCommand(BaseCommand):
                 self.console.print(f"[red]   ❌ Export failed for {module_name}[/red]")
                 self.console.print("   💡 Fix the issues and try again")
                 return 1
-            else:
-                export_path = self._get_export_path_for_module(module_name)
-                export_label = self._get_primary_export_label(module_name)
-                self.console.print(f"   ✅ Exported: {export_path}")
-                self.console.print("   ✅ Updated: data/trentorch/__init__.py")
-                self.console.print()
-                self.console.print(
-                    f"   [dim]Your {export_label} implementation is now part of the framework![/dim]"
-                )
+            export_path = self._get_export_path_for_module(module_name)
+            export_label = self._get_primary_export_label(module_name)
+            self.console.print(f"   ✅ Exported: {export_path}")
+            self.console.print("   ✅ Updated: data/trentorch/__init__.py")
+            self.console.print()
+            self.console.print(
+                f"   [dim]Your {export_label} implementation is now part of the framework![/dim]"
+            )
 
         # Step 3: Run INTEGRATION tests (AFTER export, since they import from trentorch.core.*)
         if not skip_tests:
@@ -641,7 +639,6 @@ class ModuleWorkflowCommand(BaseCommand):
             _t0 = time.time()
             integration_result = run_integration_tests(self.config, self.console, module_name, verbose=True)
             _profile(module_name, "step3_integration_tests", time.time() - _t0)
-            integration_result["passed"]
 
             if integration_result["failed"] > 0:
                 self.console.print()
@@ -746,7 +743,7 @@ class ModuleWorkflowCommand(BaseCommand):
         from rich import box
 
         module_mapping = get_module_mapping()
-        module_nums = sorted(module_mapping.keys(), key=lambda x: int(x))
+        module_nums = sorted(module_mapping.keys(), key=int)
 
         console = self.console
         console.print(
@@ -808,17 +805,16 @@ class ModuleWorkflowCommand(BaseCommand):
                 )
             )
             return 0
-        else:
-            console.print(
-                Panel(
-                    f"[bold red]❌ Module completion failed[/bold red]\n\n"
-                    f"Passed: {passed}  Failed: {failed}  Skipped: {skipped}",
-                    title="⚠️ Failure",
-                    border_style="red",
-                    box=box.ROUNDED,
-                )
+        console.print(
+            Panel(
+                f"[bold red]❌ Module completion failed[/bold red]\n\n"
+                f"Passed: {passed}  Failed: {failed}  Skipped: {skipped}",
+                title="⚠️ Failure",
+                border_style="red",
+                box=box.ROUNDED,
             )
-            return 1
+        )
+        return 1
 
     def _complete_module_quiet(
         self, module_num: str, module_name: str, skip_tests: bool, skip_export: bool

--- a/platforms/cli/tests/test_server.py
+++ b/platforms/cli/tests/test_server.py
@@ -78,7 +78,7 @@ def test_serve_command_no_browser_suppresses_open(monkeypatch):
     from unittest.mock import MagicMock, patch
 
     opened_urls: list[str] = []
-    monkeypatch.setattr(webbrowser, "open", lambda url: opened_urls.append(url))
+    monkeypatch.setattr(webbrowser, "open", opened_urls.append)
 
     config = CLIConfig.from_project_root()
     cmd = ServeCommand(config)


### PR DESCRIPTION
## Change

Real, safe fixes only, verified via pylint (CodeFactor's own default `.pylintrc`) after each one:

- `workflow.py`: removed two dead statements (`unit_result["passed"]`, `integration_result["passed"]`) whose result was discarded entirely, a no-op; de-indented two `if`/`return` blocks whose `else` was redundant since the `if` branch always returns; replaced `key=lambda x: int(x)` with `key=int`.
- `dev/test.py`: same no-else-return and lambda cleanups (5 sites, 2 lambdas).
- `test_server.py`: `monkeypatch.setattr(webbrowser, "open", lambda url: opened_urls.append(url))` simplified to `opened_urls.append` directly (pylint's unnecessary-lambda).

## What I deliberately left alone

One `no-else-return` in each of `workflow.py` and `dev/test.py`:

- `workflow.py`'s is the first branch of a ~10-way command-dispatch `elif` chain. Converting just that one branch to a bare `if` (pylint's literal suggestion) would break the chain's visual parallelism for zero behavior change, since every branch already returns.
- `dev/test.py`'s is a large `if ci_mode: / else:` block (~150 lines). The mechanical risk of a big re-indent outweighs a purely cosmetic, zero-behavior-difference simplification.

## Verified

Full `platforms/cli/tests` suite (525 tests) green, `ruff check`/`ruff format --check` clean.