### PR TITLE
chore: suppress two more bandit false positives with scoped nosec

### DIFF
--- a/platforms/cli/server/command.py
+++ b/platforms/cli/server/command.py
@@ -68,7 +68,7 @@ class ServeCommand(BaseCommand):
         is_loopback = self._is_loopback(host)
 
         # The browser cannot open 0.0.0.0 / ::, so point it at localhost.
-        browser_host = "localhost" if host in {"0.0.0.0", "::", ""} else host
+        browser_host = "localhost" if host in {"0.0.0.0", "::", ""} else host  # nosec B104 -- mapping a bind-all address to a browser-openable URL, not a bind call
         url = f"http://{browser_host}:{port}"
 
         # Inject config into handler.

--- a/platforms/cli/tests/test_jupyter_magic_exit_shutdown.py
+++ b/platforms/cli/tests/test_jupyter_magic_exit_shutdown.py
@@ -47,7 +47,7 @@ def _exit_magic(monkeypatch, shell):
     monkeypatch.setattr(jupyter_magic_module, "_running_server", lambda: (None, None))
     monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: None)
 
-    magic = TrenMagics(shell=shell)
+    magic = TrenMagics(shell=shell)  # nosec B604 -- IPython's shell kwarg, not subprocess's shell=True
     magic.exit("")
     return exit_calls
 


### PR DESCRIPTION
## Change

Two more CodeFactor/bandit findings, both single-line, in otherwise real, actively-used files, so a whole-file Ignore Files exclusion (used for the earlier batch) would have been the wrong tool here.

- `server/command.py:71` (B104, "possible binding to all interfaces"): the flagged line only maps a bind-all host to `localhost` for the browser-openable URL, it never binds anything. The actual bind happens elsewhere with the real `host` variable.
- `test_jupyter_magic_exit_shutdown.py:50` (B604, shell=True): bandit pattern-matches any `shell=` keyword argument; this is IPython's own `shell` kwarg on `TrenMagics`'s constructor, unrelated to subprocess's `shell=True`.

Each `# nosec` is scoped to its specific rule ID with an inline reason, not a bare `# nosec`, so neither line goes fully unaudited for anything else bandit might flag there later.

## Verified

Bandit no longer reports either finding (confirmed locally), `ruff check`/`ruff format --check` clean, and the relevant test suites (39 tests across `test_server.py`, `test_jupyter_magic_exit_shutdown.py`, and related) all green.